### PR TITLE
Validations, visit queue entry, and search implementations

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/QueueModuleConstants.java
+++ b/api/src/main/java/org/openmrs/module/queue/QueueModuleConstants.java
@@ -1,0 +1,19 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue;
+
+public class QueueModuleConstants {
+	
+	public final static String QUEUE_STATUS = "queue.statusConceptSetName";
+	
+	public final static String QUEUE_PRIORITY = "queue.priorityConceptSetName";
+	
+	public final static String QUEUE_SERVICE = "queue.serviceConceptSetName";
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
@@ -67,4 +67,12 @@ public interface QueueEntryService {
 	 * @return {@link java.util.Collection} of queue entries with the specified statuses
 	 */
 	Collection<QueueEntry> searchQueueEntries(@NotNull String status, boolean includeVoided);
+	
+	/**
+	 * Gets count of queue entries by status
+	 *
+	 * @param status the queue entry status
+	 * @return {@link java.lang.Long} count of queue entries by specified status
+	 */
+	Long getQueueEntriesCountByStatus(@NotNull String status);
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
@@ -11,6 +11,7 @@ package org.openmrs.module.queue.api;
 
 import javax.validation.constraints.NotNull;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import org.openmrs.api.APIException;
@@ -57,4 +58,13 @@ public interface QueueEntryService {
 	 * @throws org.openmrs.api.APIException
 	 */
 	void purgeQueueEntry(@NotNull QueueEntry queueEntry) throws APIException;
+	
+	/**
+	 * Search for queue entries by status
+	 *
+	 * @param status queue entry status
+	 * @param includeVoided include/exclude voided queue entries
+	 * @return {@link java.util.Collection} of queue entries with the specified statuses
+	 */
+	Collection<QueueEntry> searchQueueEntries(@NotNull String status, boolean includeVoided);
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/VisitQueueEntryService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/VisitQueueEntryService.java
@@ -1,0 +1,43 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+import org.openmrs.module.queue.model.VisitQueueEntry;
+
+public interface VisitQueueEntryService {
+	
+	/**
+	 * Gets a visit queue entry given UUID.
+	 *
+	 * @param uuid uuid of the visit queue entry to be returned.
+	 * @return {@link org.openmrs.module.queue.model.VisitQueueEntry}
+	 */
+	Optional<VisitQueueEntry> getVisitQueueEntryByUuid(@NotNull String uuid);
+	
+	/**
+	 * Saves a visit queue entry record
+	 *
+	 * @param visitQueueEntry the visit queue entry to be saved
+	 * @return saved {@link org.openmrs.module.queue.model.VisitQueueEntry}
+	 */
+	VisitQueueEntry createVisitQueueEntry(@NotNull VisitQueueEntry visitQueueEntry);
+	
+	/**
+	 * Voids a visit queue entry record
+	 *
+	 * @param visitQueueEntryUuid uuid of the queue entry to be voided
+	 * @param voidReason the reason for voiding the queue entry
+	 */
+	void voidVisitQueueEntry(@NotNull String visitQueueEntryUuid, String voidReason);
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/VisitQueueEntryService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/VisitQueueEntryService.java
@@ -13,6 +13,7 @@ import javax.validation.constraints.NotNull;
 
 import java.util.Optional;
 
+import org.openmrs.api.APIException;
 import org.openmrs.module.queue.model.VisitQueueEntry;
 
 public interface VisitQueueEntryService {
@@ -40,4 +41,12 @@ public interface VisitQueueEntryService {
 	 * @param voidReason the reason for voiding the queue entry
 	 */
 	void voidVisitQueueEntry(@NotNull String visitQueueEntryUuid, String voidReason);
+	
+	/**
+	 * Completely remove a visit queue entry from the database
+	 *
+	 * @param visitQueueEntry visit queue entry to be deleted
+	 * @throws org.openmrs.api.APIException
+	 */
+	void purgeQueueEntry(@NotNull VisitQueueEntry visitQueueEntry) throws APIException;
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/QueueEntryDao.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/QueueEntryDao.java
@@ -9,7 +9,22 @@
  */
 package org.openmrs.module.queue.api.dao;
 
+import javax.validation.constraints.NotNull;
+
+import java.util.Collection;
+
 import org.openmrs.Auditable;
 import org.openmrs.OpenmrsObject;
+import org.openmrs.module.queue.model.QueueEntry;
 
-public interface QueueEntryDao<Q extends OpenmrsObject & Auditable> extends BaseQueueDao<Q> {}
+public interface QueueEntryDao<Q extends OpenmrsObject & Auditable> extends BaseQueueDao<Q> {
+	
+	/**
+	 * Searches queue entries by status
+	 *
+	 * @param status the queueEntry status
+	 * @param includeVoided Include/exclude voided queue entries
+	 * @return {@link java.util.Collection} of queue entries with the specified status
+	 */
+	Collection<QueueEntry> SearchQueueEntries(@NotNull String status, boolean includeVoided);
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/QueueEntryDao.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/QueueEntryDao.java
@@ -27,4 +27,12 @@ public interface QueueEntryDao<Q extends OpenmrsObject & Auditable> extends Base
 	 * @return {@link java.util.Collection} of queue entries with the specified status
 	 */
 	Collection<QueueEntry> SearchQueueEntries(@NotNull String status, boolean includeVoided);
+	
+	/**
+	 * Gets count of queue entries by given status
+	 *
+	 * @param status the queue entry status
+	 * @return {@link java.lang.Long} count of queue entries by status
+	 */
+	Long getQueueEntriesCountByStatus(@NotNull String status);
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/VisitQueueEntryDao.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/VisitQueueEntryDao.java
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api.dao;
+
+import org.openmrs.Auditable;
+import org.openmrs.OpenmrsObject;
+
+public interface VisitQueueEntryDao<Q extends OpenmrsObject & Auditable> extends BaseQueueDao<Q> {}

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
@@ -9,18 +9,46 @@
  */
 package org.openmrs.module.queue.api.dao.impl;
 
+import javax.validation.constraints.NotNull;
+
+import java.util.Collection;
+
+import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
+import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Property;
+import org.hibernate.criterion.Restrictions;
+import org.openmrs.ConceptName;
 import org.openmrs.module.queue.api.dao.QueueEntryDao;
 import org.openmrs.module.queue.model.QueueEntry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Repository;
 
+@SuppressWarnings("unchecked")
 @Repository("queue.QueueEntryDao")
 public class QueueEntryDaoImpl extends AbstractBaseQueueDaoImpl<QueueEntry> implements QueueEntryDao<QueueEntry> {
 	
 	@Autowired
 	public QueueEntryDaoImpl(@Qualifier("sessionFactory") SessionFactory sessionFactory) {
 		super(sessionFactory);
+	}
+	
+	/**
+	 * @see org.openmrs.module.queue.api.dao.QueueEntryDao#SearchQueueEntries(String, boolean)
+	 */
+	@Override
+	public Collection<QueueEntry> SearchQueueEntries(@NotNull String status, boolean includeVoided) {
+		//subQuery
+		DetachedCriteria subQuery = DetachedCriteria.forClass(ConceptName.class, "cn")
+		        .add(Restrictions.eq("cn.name", status)).setProjection(Projections.property("cn.concept"));
+		
+		Criteria criteria = getCurrentSession().createCriteria(QueueEntry.class, "qe");
+		//Include/exclude retired queues
+		includeVoidedObjects(criteria, includeVoided);
+		criteria.add(Property.forName("qe.status").in(subQuery));
+		
+		return criteria.list();
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/VisitQueueEntryDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/VisitQueueEntryDaoImpl.java
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api.dao.impl;
+
+import org.hibernate.SessionFactory;
+import org.openmrs.module.queue.api.dao.VisitQueueEntryDao;
+import org.openmrs.module.queue.model.VisitQueueEntry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+@Repository("queue.VisitQueueEntryDao")
+public class VisitQueueEntryDaoImpl extends AbstractBaseQueueDaoImpl<VisitQueueEntry> implements VisitQueueEntryDao<VisitQueueEntry> {
+	
+	@Autowired
+	public VisitQueueEntryDaoImpl(@Qualifier("sessionFactory") SessionFactory sessionFactory) {
+		super(sessionFactory);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
@@ -11,6 +11,7 @@ package org.openmrs.module.queue.api.impl;
 
 import javax.validation.constraints.NotNull;
 
+import java.util.Collection;
 import java.util.Date;
 import java.util.Optional;
 
@@ -81,5 +82,13 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	@Override
 	public void purgeQueueEntry(QueueEntry queueEntry) throws APIException {
 		this.dao.delete(queueEntry);
+	}
+	
+	/**
+	 * @see org.openmrs.module.queue.api.QueueEntryService#searchQueueEntries(String, boolean)
+	 */
+	@Override
+	public Collection<QueueEntry> searchQueueEntries(String status, boolean includeVoided) {
+		return this.dao.SearchQueueEntries(status, includeVoided);
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
@@ -91,4 +91,12 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	public Collection<QueueEntry> searchQueueEntries(String status, boolean includeVoided) {
 		return this.dao.SearchQueueEntries(status, includeVoided);
 	}
+	
+	/**
+	 * @see org.openmrs.module.queue.api.QueueEntryService#getQueueEntriesCountByStatus(String)
+	 */
+	@Override
+	public Long getQueueEntriesCountByStatus(@NotNull String status) {
+		return this.dao.getQueueEntriesCountByStatus(status);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/VisitQueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/VisitQueueEntryServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 import lombok.AccessLevel;
 import lombok.Setter;
+import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.queue.api.VisitQueueEntryService;
@@ -52,5 +53,10 @@ public class VisitQueueEntryServiceImpl extends BaseOpenmrsService implements Vi
 			visitQueueEntry.setVoidedBy(Context.getAuthenticatedUser());
 			this.dao.createOrUpdate(visitQueueEntry);
 		});
+	}
+	
+	@Override
+	public void purgeQueueEntry(@NotNull VisitQueueEntry visitQueueEntry) throws APIException {
+		this.dao.delete(visitQueueEntry);
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/VisitQueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/VisitQueueEntryServiceImpl.java
@@ -1,0 +1,56 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api.impl;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Date;
+import java.util.Optional;
+
+import lombok.AccessLevel;
+import lombok.Setter;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.impl.BaseOpenmrsService;
+import org.openmrs.module.queue.api.VisitQueueEntryService;
+import org.openmrs.module.queue.api.dao.VisitQueueEntryDao;
+import org.openmrs.module.queue.model.VisitQueueEntry;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Setter(AccessLevel.MODULE)
+public class VisitQueueEntryServiceImpl extends BaseOpenmrsService implements VisitQueueEntryService {
+	
+	private VisitQueueEntryDao<VisitQueueEntry> dao;
+	
+	public void setDao(VisitQueueEntryDao<VisitQueueEntry> dao) {
+		this.dao = dao;
+	}
+	
+	@Override
+	public Optional<VisitQueueEntry> getVisitQueueEntryByUuid(@NotNull String uuid) {
+		return this.dao.get(uuid);
+	}
+	
+	@Override
+	public VisitQueueEntry createVisitQueueEntry(@NotNull VisitQueueEntry visitQueueEntry) {
+		return this.dao.createOrUpdate(visitQueueEntry);
+	}
+	
+	@Override
+	public void voidVisitQueueEntry(@NotNull String visitQueueEntryUuid, String voidReason) {
+		this.dao.get(visitQueueEntryUuid).ifPresent(visitQueueEntry -> {
+			visitQueueEntry.setVoided(true);
+			visitQueueEntry.setDateVoided(new Date());
+			visitQueueEntry.setVoidReason(voidReason);
+			visitQueueEntry.setVoidedBy(Context.getAuthenticatedUser());
+			this.dao.createOrUpdate(visitQueueEntry);
+		});
+	}
+}

--- a/api/src/main/java/org/openmrs/module/queue/model/QueueEntry.java
+++ b/api/src/main/java/org/openmrs/module/queue/model/QueueEntry.java
@@ -20,9 +20,10 @@ import javax.persistence.Table;
 
 import java.util.Date;
 
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.openmrs.BaseChangeableOpenmrsData;
 import org.openmrs.Concept;
 import org.openmrs.Location;
@@ -31,7 +32,8 @@ import org.openmrs.Provider;
 
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
-@Data
+@Setter
+@Getter
 @Entity
 @Table(name = "queue_entry")
 public class QueueEntry extends BaseChangeableOpenmrsData {
@@ -93,5 +95,14 @@ public class QueueEntry extends BaseChangeableOpenmrsData {
 	@Override
 	public void setId(Integer id) {
 		this.setQueueEntryId(id);
+	}
+
+	//Break the cyclic dependency
+	@Override
+	public String toString() {
+		return "QueueEntry{" + "queueEntryId=" + queueEntryId + ", patient=" + patient + ", service=" + service
+		        + ", priority=" + priority + ", priorityComment='" + priorityComment + '\'' + ", status=" + status
+		        + ", sortWeight=" + sortWeight + ", locationWaitingFor=" + locationWaitingFor + ", providerWaitingFor="
+		        + providerWaitingFor + ", startedAt=" + startedAt + ", endedAt=" + endedAt + '}';
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/model/QueueEntry.java
+++ b/api/src/main/java/org/openmrs/module/queue/model/QueueEntry.java
@@ -96,7 +96,7 @@ public class QueueEntry extends BaseChangeableOpenmrsData {
 	public void setId(Integer id) {
 		this.setQueueEntryId(id);
 	}
-
+	
 	//Break the cyclic dependency
 	@Override
 	public String toString() {

--- a/api/src/main/java/org/openmrs/module/queue/utils/QueueValidationUtils.java
+++ b/api/src/main/java/org/openmrs/module/queue/utils/QueueValidationUtils.java
@@ -1,0 +1,81 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.utils;
+
+import javax.validation.constraints.NotNull;
+
+import lombok.extern.slf4j.Slf4j;
+import org.openmrs.Concept;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.QueueModuleConstants;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.springframework.validation.Errors;
+
+@Slf4j
+public class QueueValidationUtils {
+	
+	/**
+	 * Checks if the specified concept is a member of the conceptSet
+	 *
+	 * @param concept concept
+	 * @param property global property that identifies certain concept
+	 * @return true/false if concept belongs to a particular conceptSet
+	 */
+	public static boolean isAMember(@NotNull Concept concept, @NotNull String property) {
+		String value = Context.getAdministrationService().getGlobalProperty(property);
+		if (value == null || value.isEmpty()) {
+			//throw the appropriate exception
+			throw new IllegalArgumentException("Please configure concept set name for " + concept.getDisplayString()
+			        + " via the global property " + property);
+		}
+		Concept conceptByName = Context.getConceptService().getConceptByName(value);
+		return Context.getConceptService().getConceptsByConceptSet(conceptByName).contains(concept);
+	}
+	
+	public static void validateQueueEntry(QueueEntry queueEntry, Errors errors) {
+		if (queueEntry.getStatus() == null) {
+			errors.rejectValue("status", "QueueEntry.status.null", "The property status should not be null");
+		} else {
+			if (!isValidStatus(queueEntry.getStatus())) {
+				errors.rejectValue("status", "QueueEntry.status.invalid",
+				    "The property status should be a member of configured queue status conceptSet.");
+			}
+		}
+		if (queueEntry.getPriority() == null) {
+			errors.rejectValue("priority", "QueueEntry.priority.null", "The property priority should not be null");
+		} else {
+			if (!isValidPriority(queueEntry.getPriority())) {
+				errors.rejectValue("priority", "QueueEntry.priority.invalid",
+				    "The property priority should be a member of configured queue priority conceptSet.");
+			}
+		}
+		if (queueEntry.getService() == null) {
+			errors.rejectValue("service", "QueueEntry.service.null", "The property service should not be null");
+		} else {
+			if (!isValidService(queueEntry.getService())) {
+				errors.rejectValue("service", "QueueEntry.service.invalid",
+				    "The property service should be a member of configured queue service conceptSet.");
+			}
+		}
+		
+	}
+	
+	public static boolean isValidStatus(@NotNull Concept concept) {
+		return isAMember(concept, QueueModuleConstants.QUEUE_STATUS);
+	}
+	
+	public static boolean isValidPriority(@NotNull Concept concept) {
+		return isAMember(concept, QueueModuleConstants.QUEUE_PRIORITY);
+	}
+	
+	public static boolean isValidService(@NotNull Concept concept) {
+		return isAMember(concept, QueueModuleConstants.QUEUE_SERVICE);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/queue/validators/QueueEntryValidator.java
+++ b/api/src/main/java/org/openmrs/module/queue/validators/QueueEntryValidator.java
@@ -1,0 +1,40 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.validators;
+
+import static org.springframework.validation.ValidationUtils.rejectIfEmptyOrWhitespace;
+
+import org.openmrs.annotation.Handler;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.openmrs.module.queue.utils.QueueValidationUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+@Handler(supports = { QueueEntry.class }, order = 50)
+public class QueueEntryValidator implements Validator {
+	
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return QueueEntry.class.isAssignableFrom(clazz);
+	}
+	
+	@Override
+	public void validate(Object target, Errors errors) {
+		if (!(target instanceof QueueEntry)) {
+			throw new IllegalArgumentException("the parameter target must be of type " + QueueEntry.class);
+		}
+		rejectIfEmptyOrWhitespace(errors, "patient", "queueEntry.patient.null", "The property patient should not be null");
+		rejectIfEmptyOrWhitespace(errors, "startedAt", "queueEntry.startedAt.null",
+		    "The property startedAt should not be null");
+		
+		QueueEntry queueEntry = (QueueEntry) target;
+		QueueValidationUtils.validateQueueEntry(queueEntry, errors);
+	}
+}

--- a/api/src/main/java/org/openmrs/module/queue/validators/QueueValidator.java
+++ b/api/src/main/java/org/openmrs/module/queue/validators/QueueValidator.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs.module.queue.validators;
 
+import javax.validation.constraints.NotNull;
+
 import lombok.extern.slf4j.Slf4j;
 import org.openmrs.Location;
 import org.openmrs.annotation.Handler;
@@ -38,17 +40,25 @@ public class QueueValidator implements Validator {
 			throw new IllegalArgumentException("The parameter target should not be null & must be of type" + Queue.class);
 		}
 		Queue queue = (Queue) target;
-		Location location = queue.getLocation();
-		if (location == null) {
-			errors.rejectValue("location", "queue.location.null", "Location is null");
-		} else {
-			//Is the location valid? consider tagging locations
-			Location isExistentLocation = Context.getLocationService().getLocationByUuid(location.getUuid());
-			if (isExistentLocation == null) {
-				errors.rejectValue("location", "queue.location.non-existent",
-				    "Could not find location with uuid " + location.getUuid());
-			}
-		}
 		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "queue.name.null", "Queue name can't be null");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "location", "queue.location.null", "Location can't be null");
+		
+		if (!isValidLocation(queue.getLocation())) {
+			errors.rejectValue("location", "queue.location.null", "Location is null or doesn't exists");
+		}
+	}
+	
+	/**
+	 * For now checks for existence
+	 * 
+	 * @param location location to check if it exists
+	 * @return true or false if the location exists
+	 */
+	public boolean isValidLocation(@NotNull Location location) {
+		if (location == null) {
+			return false;
+		}
+		Location isExistentLocation = Context.getLocationService().getLocationByUuid(location.getUuid());
+		return isExistentLocation != null;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/validators/QueueValidator.java
+++ b/api/src/main/java/org/openmrs/module/queue/validators/QueueValidator.java
@@ -1,0 +1,54 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.validators;
+
+import lombok.extern.slf4j.Slf4j;
+import org.openmrs.Location;
+import org.openmrs.annotation.Handler;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.model.Queue;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+
+/**
+ * Validates Queue object
+ */
+@Slf4j
+@Handler(supports = { Queue.class }, order = 50)
+public class QueueValidator implements Validator {
+	
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return Queue.class.isAssignableFrom(clazz);
+	}
+	
+	@Override
+	public void validate(Object target, Errors errors) {
+		log.debug("{}.validate", this.getClass().getName());
+		//instanceof checks for null
+		if (!(target instanceof Queue)) {
+			throw new IllegalArgumentException("The parameter target should not be null & must be of type" + Queue.class);
+		}
+		Queue queue = (Queue) target;
+		Location location = queue.getLocation();
+		if (location == null) {
+			errors.rejectValue("location", "queue.location.null", "Location is null");
+		} else {
+			//Is the location valid? consider tagging locations
+			Location isExistentLocation = Context.getLocationService().getLocationByUuid(location.getUuid());
+			if (isExistentLocation == null) {
+				errors.rejectValue("location", "queue.location.non-existent",
+				    "Could not find location with uuid " + location.getUuid());
+			}
+		}
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "queue.name.null", "Queue name can't be null");
+	}
+}

--- a/api/src/main/java/org/openmrs/module/queue/validators/VisitQueueEntryValidator.java
+++ b/api/src/main/java/org/openmrs/module/queue/validators/VisitQueueEntryValidator.java
@@ -1,0 +1,41 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.validators;
+
+import org.openmrs.annotation.Handler;
+import org.openmrs.module.queue.model.VisitQueueEntry;
+import org.openmrs.module.queue.utils.QueueValidationUtils;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+
+@Handler(supports = { VisitQueueEntry.class }, order = 50)
+public class VisitQueueEntryValidator implements Validator {
+	
+	@Override
+	public boolean supports(Class<?> clazz) {
+		return VisitQueueEntry.class.isAssignableFrom(clazz);
+	}
+	
+	@Override
+	public void validate(Object target, Errors errors) {
+		if (!(target instanceof VisitQueueEntry)) {
+			throw new IllegalArgumentException("the parameter target must be of type " + VisitQueueEntry.class);
+		}
+		//Reject null visit & queueEntry
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "visit", "visitQueueEntry.visit.null",
+		    "The property visit should not be null");
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "queueEntry", "visitQueueEntry.queueEntry.null",
+		    "The property queueEntry should not be null");
+		
+		VisitQueueEntry visitQueueEntry = (VisitQueueEntry) target;
+		QueueValidationUtils.validateQueueEntry(visitQueueEntry.getQueueEntry(), errors);
+	}
+}

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -63,4 +63,24 @@
             </list>
         </property>
     </bean>
+
+    <bean id="queue.VisitQueueEntryService"
+          class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+        <property name="transactionManager" ref="transactionManager"/>
+        <property name="target">
+            <bean class="org.openmrs.module.queue.api.impl.VisitQueueEntryServiceImpl">
+                <property name="dao" ref="queue.VisitQueueEntryDao" />
+            </bean>
+        </property>
+        <property name="preInterceptors" ref="serviceInterceptors"/>
+        <property name="transactionAttributeSource" ref="transactionAttributeSource"/>
+    </bean>
+    <bean parent="serviceContext">
+        <property name="moduleService">
+            <list>
+                <value>org.openmrs.module.queue.api.VisitQueueEntryService</value>
+                <ref bean="queue.VisitQueueEntryService" />
+            </list>
+        </property>
+    </bean>
 </beans>

--- a/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
@@ -35,6 +35,10 @@ public class QueueEntryServiceTest {
 	
 	private static final Integer QUEUE_ENTRY_ID = 14;
 	
+	private static final String QUEUE_ENTRY_STATUS = "Waiting for Service";
+	
+	private static final String BAD_QUEUE_ENTRY_STATUS = "Waiting for Service";
+	
 	private QueueEntryServiceImpl queueEntryService;
 	
 	@Mock
@@ -106,5 +110,19 @@ public class QueueEntryServiceTest {
 		
 		queueEntryService.purgeQueueEntry(queueEntry);
 		assertThat(queueEntryService.getQueueEntryByUuid(QUEUE_ENTRY_UUID).isPresent(), is(false));
+	}
+	
+	@Test
+	public void shouldReturnCountOfQueueEntriesByStatus() {
+		when(dao.getQueueEntriesCountByStatus(QUEUE_ENTRY_STATUS)).thenReturn(1L);
+		
+		assertThat(queueEntryService.getQueueEntriesCountByStatus(QUEUE_ENTRY_STATUS), is(1L));
+	}
+	
+	@Test
+	public void shouldReturnZeroForBadGivenStatus() {
+		when(dao.getQueueEntriesCountByStatus(BAD_QUEUE_ENTRY_STATUS)).thenReturn(0L);
+		
+		assertThat(queueEntryService.getQueueEntriesCountByStatus(QUEUE_ENTRY_STATUS), is(0L));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/queue/api/VisitQueueEntryServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/VisitQueueEntryServiceTest.java
@@ -1,0 +1,86 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.openmrs.Visit;
+import org.openmrs.module.queue.api.dao.VisitQueueEntryDao;
+import org.openmrs.module.queue.api.impl.VisitQueueEntryServiceImpl;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.openmrs.module.queue.model.VisitQueueEntry;
+
+@RunWith(MockitoJUnitRunner.class)
+public class VisitQueueEntryServiceTest {
+	
+	private static final String VISIT_QUEUE_ENTRY_UUID = "j8f0bb90-86f4-4d9c-8b6c-3713d748ef74";
+	
+	private VisitQueueEntryServiceImpl visitQueueEntryService;
+	
+	@Mock
+	private VisitQueueEntryDao<VisitQueueEntry> dao;
+	
+	@Before
+	public void setupMocks() {
+		MockitoAnnotations.openMocks(this);
+		visitQueueEntryService = new VisitQueueEntryServiceImpl();
+		visitQueueEntryService.setDao(dao);
+	}
+	
+	@Test
+	public void shouldGetVisitQueueEntryByUuid() {
+		VisitQueueEntry visitQueueEntry = mock(VisitQueueEntry.class);
+		when(visitQueueEntry.getUuid()).thenReturn(VISIT_QUEUE_ENTRY_UUID);
+		when(dao.get(VISIT_QUEUE_ENTRY_UUID)).thenReturn(Optional.of(visitQueueEntry));
+		
+		Optional<VisitQueueEntry> result = visitQueueEntryService.getVisitQueueEntryByUuid(VISIT_QUEUE_ENTRY_UUID);
+		assertThat(result.isPresent(), is(true));
+		result.ifPresent(q -> assertThat(q.getUuid(), is(VISIT_QUEUE_ENTRY_UUID)));
+	}
+	
+	@Test
+	public void shouldCreateNewRecordForVisitQueueEntry() {
+		VisitQueueEntry visitQueueEntry = mock(VisitQueueEntry.class);
+		Visit visit = mock(Visit.class);
+		QueueEntry queueEntry = mock(QueueEntry.class);
+		
+		when(visitQueueEntry.getQueueEntry()).thenReturn(queueEntry);
+		when(visitQueueEntry.getVisit()).thenReturn(visit);
+		when(dao.createOrUpdate(visitQueueEntry)).thenReturn(visitQueueEntry);
+		
+		VisitQueueEntry result = this.dao.createOrUpdate(visitQueueEntry);
+		assertThat(result, notNullValue());
+		assertThat(result.getVisit(), is(visit));
+		assertThat(result.getQueueEntry(), is(queueEntry));
+		
+	}
+	
+	@Test
+	public void shouldVoidVisitQueueEntryRecord() {
+		when(dao.get(VISIT_QUEUE_ENTRY_UUID)).thenReturn(Optional.empty());
+		
+		visitQueueEntryService.voidVisitQueueEntry(VISIT_QUEUE_ENTRY_UUID, "voidReason");
+		
+		assertThat(visitQueueEntryService.getVisitQueueEntryByUuid(VISIT_QUEUE_ENTRY_UUID).isPresent(), is(false));
+	}
+	
+}

--- a/api/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
@@ -60,6 +60,8 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_conceptsInitialDataset.xml",
 	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_initialDataset.xml");
 	
+	private static final String QUEUE_ENTRY_STATUS = "Waiting for service";
+	
 	@Autowired
 	@Qualifier("queue.QueueEntryDao")
 	private QueueEntryDao<QueueEntry> dao;
@@ -199,5 +201,29 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 		assertThat(conceptQueueService, notNullValue());
 		assertThat(conceptQueueService.getUuid(), is(QUEUE_SERVICE_CONCEPT_UUID));
 		queueEntry.setService(conceptQueueService);
+	}
+	
+	@Test
+	public void shouldSearchQueueEntriesByStatus() {
+		Collection<QueueEntry> queueEntries = dao.SearchQueueEntries(QUEUE_ENTRY_STATUS, false);
+		
+		assertThat(queueEntries.isEmpty(), is(false));
+		assertThat(queueEntries, hasSize(1));
+		queueEntries.forEach(queueEntry -> {
+			assertThat(queueEntry.getStatus(), notNullValue());
+			assertThat(queueEntry.getStatus().getName().getName(), is(QUEUE_ENTRY_STATUS));
+		});
+	}
+	
+	@Test
+	public void shouldSearchQueueEntriesByStatusIncludingVoidedQueueEntries() {
+		Collection<QueueEntry> queueEntries = dao.SearchQueueEntries(QUEUE_ENTRY_STATUS, true);
+		
+		assertThat(queueEntries.isEmpty(), is(false));
+		assertThat(queueEntries, hasSize(2));
+		queueEntries.forEach(queueEntry -> {
+			assertThat(queueEntry.getStatus(), notNullValue());
+			assertThat(queueEntry.getStatus().getName().getName(), is(QUEUE_ENTRY_STATUS));
+		});
 	}
 }

--- a/api/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
@@ -62,6 +62,8 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	
 	private static final String QUEUE_ENTRY_STATUS = "Waiting for service";
 	
+	private static final String BAD_QUEUE_ENTRY_STATUS = "Bad Waiting for service";
+	
 	@Autowired
 	@Qualifier("queue.QueueEntryDao")
 	private QueueEntryDao<QueueEntry> dao;
@@ -225,5 +227,21 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 			assertThat(queueEntry.getStatus(), notNullValue());
 			assertThat(queueEntry.getStatus().getName().getName(), is(QUEUE_ENTRY_STATUS));
 		});
+	}
+	
+	@Test
+	public void shouldCountQueueEntriesByStatus() {
+		Long queueEntriesCountByStatusCount = dao.getQueueEntriesCountByStatus(QUEUE_ENTRY_STATUS);
+		
+		assertThat(queueEntriesCountByStatusCount, notNullValue());
+		assertThat(queueEntriesCountByStatusCount, is(1L));
+	}
+	
+	@Test
+	public void shouldZeroCountQueueEntriesByBadStatus() {
+		Long queueEntriesCountByStatusCount = dao.getQueueEntriesCountByStatus(BAD_QUEUE_ENTRY_STATUS);
+		
+		assertThat(queueEntriesCountByStatusCount, notNullValue());
+		assertThat(queueEntriesCountByStatusCount, is(0L));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest.java
@@ -1,0 +1,159 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api.dao;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Visit;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.SpringTestConfiguration;
+import org.openmrs.module.queue.api.QueueEntryService;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.openmrs.module.queue.model.VisitQueueEntry;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(classes = SpringTestConfiguration.class, inheritLocations = false)
+public class VisitQueueEntryDaoTest extends BaseModuleContextSensitiveTest {
+	
+	private static final String VISIT_QUEUE_ENTRY_UUID = "5eb8fe43-2813-4kbc-80dc-2e5d30252cc3";
+	
+	private static final String NEW_VISIT_QUEUE_ENTRY_UUID = "7eb6fe43-2813-4kbc-80dc-2e5d30252kk9";
+	
+	private static final String VOIDED_VISIT_QUEUE_ENTRY_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc6";
+	
+	private static final String QUEUE_ENTRY_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc6";
+	
+	private static final String VISIT_UUID = "j848b0c0-1ade-11e1-9c71-00248140a6eb";
+	
+	@Autowired
+	@Qualifier("queue.VisitQueueEntryDao")
+	private VisitQueueEntryDao<VisitQueueEntry> dao;
+	
+	//the order of the list is important!
+	private static final List<String> VISIT_QUEUE_ENTRY_INITIAL_DATASET_XML = Arrays.asList(
+	    "org/openmrs/module/queue/api/dao/QueueDaoTest_locationInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueDaoTest_initialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_patientInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_conceptsInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_initialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest_visitInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/visitQueueEntryDaoTest_initialDataset.xml");
+	
+	@Before
+	public void setup() {
+		VISIT_QUEUE_ENTRY_INITIAL_DATASET_XML.forEach(this::executeDataSet);
+	}
+	
+	@Test
+	public void shouldGetVisitQueueEntryByUuid() {
+		Optional<VisitQueueEntry> result = dao.get(VISIT_QUEUE_ENTRY_UUID);
+		
+		assertThat(result, notNullValue());
+		assertThat(result.isPresent(), is(true));
+		assertThat(result.get().getUuid(), is(VISIT_QUEUE_ENTRY_UUID));
+	}
+	
+	@Test
+	public void shouldReturnNullForVoidedVisitQueueEntry() {
+		Optional<VisitQueueEntry> visitQueueEntry = dao.get(VOIDED_VISIT_QUEUE_ENTRY_UUID);
+		assertThat(visitQueueEntry.isPresent(), is(false));
+	}
+	
+	@Test
+	public void shouldCreateNewVisitQueryEntryRecord() {
+		VisitQueueEntry visitQueueEntry = new VisitQueueEntry();
+		visitQueueEntry.setUuid(NEW_VISIT_QUEUE_ENTRY_UUID);
+		Optional<QueueEntry> queueEntryOptional = Context.getService(QueueEntryService.class)
+		        .getQueueEntryByUuid(QUEUE_ENTRY_UUID);
+		assertThat(queueEntryOptional.isPresent(), is(true));
+		queueEntryOptional.ifPresent(visitQueueEntry::setQueueEntry);
+		
+		Visit visit = Context.getVisitService().getVisitByUuid(VISIT_UUID);
+		assertThat(visit, notNullValue());
+		visitQueueEntry.setVisit(visit);
+		visitQueueEntry.setDateCreated(new Date());
+		
+		VisitQueueEntry result = dao.createOrUpdate(visitQueueEntry);
+		assertThat(result, notNullValue());
+		assertThat(result.getUuid(), is(NEW_VISIT_QUEUE_ENTRY_UUID));
+		assertThat(result.getQueueEntry(), notNullValue());
+		assertThat(result.getQueueEntry().getUuid(), is(QUEUE_ENTRY_UUID));
+	}
+	
+	@Test
+	public void shouldUpdateAnExistingVisitQueueEntryRecord() {
+		Optional<VisitQueueEntry> existingVisitQueueEntry = dao.get(VISIT_QUEUE_ENTRY_UUID);
+		assertThat(existingVisitQueueEntry.isPresent(), is(true));
+		
+		//Update the existing visit_queue_entry record
+		existingVisitQueueEntry.ifPresent(visitQueueEntry -> {
+			visitQueueEntry.setVoided(true);
+			visitQueueEntry.setDateVoided(new Date());
+			visitQueueEntry.setVoidReason("Testing update operation");
+			dao.createOrUpdate(visitQueueEntry);
+		});
+		
+		//Get the updated visit_queue_entry
+		Optional<VisitQueueEntry> updatedVisitQueueEntry = dao.get(VISIT_QUEUE_ENTRY_UUID);
+		//If false - update was successful
+		assertThat(updatedVisitQueueEntry.isPresent(), is(false));
+		//Get the voided visit queue entry record
+		Optional<VisitQueueEntry> alreadyVoidedVisitQueueEntryRecord = dao.get(existingVisitQueueEntry.get().getId());
+		assertThat(alreadyVoidedVisitQueueEntryRecord.isPresent(), is(true));
+		assertThat(alreadyVoidedVisitQueueEntryRecord.get().getVoided(), is(true));
+		assertThat(alreadyVoidedVisitQueueEntryRecord.get().getVoidReason(), is("Testing update operation"));
+	}
+	
+	@Test
+	public void shouldFindAllVisitQueueEntries() {
+		Collection<VisitQueueEntry> visitQueueEntries = dao.findAll();
+		assertThat(visitQueueEntries.isEmpty(), is(false));
+		assertThat(visitQueueEntries, hasSize(1));
+	}
+	
+	@Test
+	public void shouldFindAllVisitQueueEntriesIncludingRetired() {
+		Collection<VisitQueueEntry> visitQueueEntries = dao.findAll(true);
+		assertThat(visitQueueEntries.isEmpty(), is(false));
+		assertThat(visitQueueEntries, hasSize(2));
+	}
+	
+	@Test
+	public void shouldDeleteVisitQueueEntryByUuid() {
+		dao.delete(VISIT_QUEUE_ENTRY_UUID);
+		
+		Optional<VisitQueueEntry> result = dao.get(VISIT_QUEUE_ENTRY_UUID);
+		//verify delete operation
+		assertThat(result.isPresent(), is(false));
+	}
+	
+	@Test
+	public void shouldDeleteVisitQueueEntryByEntity() {
+		dao.get(VISIT_QUEUE_ENTRY_UUID).ifPresent((queueEntry) -> dao.delete(queueEntry));
+		
+		Optional<VisitQueueEntry> result = dao.get(VISIT_QUEUE_ENTRY_UUID);
+		//verify delete operation
+		assertThat(result.isPresent(), is(false));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/queue/validators/QueueEntryValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/validators/QueueEntryValidatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.validators;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Concept;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.SpringTestConfiguration;
+import org.openmrs.module.queue.utils.QueueValidationUtils;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(classes = SpringTestConfiguration.class, inheritLocations = false)
+public class QueueEntryValidatorTest extends BaseModuleContextSensitiveTest {
+	
+	private static final String VALID_STATUS_CONCEPT = "31b910bd-298c-4ecf-a632-661ae2f4460y";
+	
+	private static final String INVALID_STATUS_CONCEPT_UUID = "67b910bd-298c-4ecf-a632-661ae2f446op";
+	
+	private static final String VALID_SERVICE_CONCEPT = "67b910bd-298c-4ecf-a632-661ae2f446op";
+	
+	private static final String INVALID_SERVICE_CONCEPT_UUID = "91b910bd-298c-4ecf-a632-661ae2f909ut";
+	
+	private static final List<String> INITIAL_CONCEPTS_DATASETS = Arrays.asList(
+	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_conceptsInitialDataset.xml",
+	    "org/openmrs/module/queue/validators/QueueEntryValidatorTest_globalPropertyInitialDataset.xml");
+	
+	@Autowired
+	private QueueEntryValidator validator;
+	
+	@Before
+	public void setup() {
+		INITIAL_CONCEPTS_DATASETS.forEach(this::executeDataSet);
+	}
+	
+	@Test
+	public void validatorNotNull() {
+		assertNotNull(validator);
+	}
+	
+	@Test
+	public void shouldReturnTrueForValidStatusConcept() {
+		Concept concept = Context.getConceptService().getConceptByUuid(VALID_STATUS_CONCEPT);
+		assertThat(concept, notNullValue());
+		assertTrue(QueueValidationUtils.isValidStatus(concept));
+	}
+	
+	@Test
+	public void shouldReturnFalseForInvalidStatusConcept() {
+		Concept concept = Context.getConceptService().getConceptByUuid(INVALID_STATUS_CONCEPT_UUID);
+		assertThat(concept, notNullValue());
+		assertFalse(QueueValidationUtils.isValidStatus(concept));
+	}
+	
+	@Test
+	public void shouldReturnTrueForValidServiceConcept() {
+		Concept concept = Context.getConceptService().getConceptByUuid(VALID_SERVICE_CONCEPT);
+		assertThat(concept, notNullValue());
+		assertTrue(QueueValidationUtils.isValidService(concept));
+	}
+	
+	@Test
+	public void shouldReturnFalseForInvalidServiceConcept() {
+		Concept concept = Context.getConceptService().getConceptByUuid(INVALID_SERVICE_CONCEPT_UUID);
+		assertThat(concept, notNullValue());
+		assertFalse(QueueValidationUtils.isValidService(concept));
+	}
+	
+}

--- a/api/src/test/java/org/openmrs/module/queue/validators/QueueValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/validators/QueueValidatorTest.java
@@ -1,0 +1,52 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.validators;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Location;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.SpringTestConfiguration;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(classes = SpringTestConfiguration.class, inheritLocations = false)
+public class QueueValidatorTest extends BaseModuleContextSensitiveTest {
+	
+	private static final String LOCATION_INITIAL_DATASET_XML = "org/openmrs/module/queue/api/dao/QueueDaoTest_locationInitialDataset.xml";
+	
+	private static final String BAD_LOCATION_UUID = "60938432-1691-11df-97a5-7038c0lk";
+	
+	private static final String LOCATION_UUID = "d0938432-1691-11df-97a5-7038c098";
+	
+	@Autowired
+	private QueueValidator validator;
+	
+	@Before
+	public void setup() {
+		executeDataSet(LOCATION_INITIAL_DATASET_XML);
+	}
+	
+	@Test
+	public void shouldTrueForValidLocation() {
+		Location location = Context.getLocationService().getLocationByUuid(LOCATION_UUID);
+		assertTrue(validator.isValidLocation(location));
+	}
+	
+	@Test
+	public void shouldFalseForBadLocation() {
+		Location location = Context.getLocationService().getLocationByUuid(BAD_LOCATION_UUID);
+		assertFalse(validator.isValidLocation(location));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/queue/validators/VisitQueueEntryValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/validators/VisitQueueEntryValidatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.validators;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Concept;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.SpringTestConfiguration;
+import org.openmrs.module.queue.api.QueueEntryService;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.openmrs.module.queue.utils.QueueValidationUtils;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(classes = { SpringTestConfiguration.class }, inheritLocations = false)
+public class VisitQueueEntryValidatorTest extends BaseModuleContextSensitiveTest {
+	
+	private static final String VALID_CONCEPT_STATUS_UUID = "4eb8fe43-2813-4kbc-80dc-2e5d30252cc6";
+	
+	private static final String INVALID_STATUS_CONCEPT_UUID = "67b910bd-298c-4ecf-a632-661ae2f446op";
+	
+	//the order of the list is important!
+	private static final List<String> VISIT_QUEUE_ENTRY_INITIAL_DATASET_XML = Arrays.asList(
+	    "org/openmrs/module/queue/api/dao/QueueDaoTest_locationInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueDaoTest_initialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_patientInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_conceptsInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_initialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest_visitInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/visitQueueEntryDaoTest_initialDataset.xml",
+	    "org/openmrs/module/queue/validators/QueueEntryValidatorTest_globalPropertyInitialDataset.xml");
+	
+	@Autowired
+	private VisitQueueEntryValidator validator;
+	
+	@Before
+	public void setup() {
+		VISIT_QUEUE_ENTRY_INITIAL_DATASET_XML.forEach(this::executeDataSet);
+	}
+	
+	@Test
+	public void validatorNotNull() {
+		assertNotNull(validator);
+	}
+	
+	@Test
+	public void shouldReturnTrueForValidStatusConcept() {
+		Optional<QueueEntry> queueEntry = Context.getService(QueueEntryService.class)
+		        .getQueueEntryByUuid(VALID_CONCEPT_STATUS_UUID);
+		assertTrue(queueEntry.isPresent());
+		QueueValidationUtils.isValidStatus(queueEntry.get().getStatus());
+	}
+	
+	@Test
+	public void shouldReturnFalseForInvalidStatusConcept() {
+		Concept concept = Context.getConceptService().getConceptByUuid(INVALID_STATUS_CONCEPT_UUID);
+		assertThat(concept, notNullValue());
+		assertFalse(QueueValidationUtils.isValidStatus(concept));
+	}
+}

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueEntryDaoTest_conceptsInitialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueEntryDaoTest_conceptsInitialDataset.xml
@@ -13,7 +13,7 @@
     <concept concept_id="1000" retired="false" is_set="true" creator="1" date_created="2022-02-02 14:31:00.0" uuid="897eba27-2b38-43e8-91a9-4dfe3956a35t"/>
     <concept concept_id="1001" retired="false" is_set="false" creator="1" date_created="2022-02-02 14:40:00.0" uuid="90b910bd-298c-4ecf-a632-661ae2f446op"/>
     <concept concept_id="1002" retired="false" is_set="false" creator="1" date_created="2022-02-02 14:40:00.0" uuid="91b910bd-298c-4ecf-a632-661ae2f909ut"/>
-    <concept_name concept_name_id="120001" concept_id="1000" name="Queue Priorities" locale="en" creator="1" date_created="2022-02-02 14:40:00.0" voided="0" uuid="9c067348-5bf2-4050-b824-0aa009436ed6" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
+    <concept_name concept_name_id="120001" concept_id="1000" name="Queue Priority" locale="en" creator="1" date_created="2022-02-02 14:40:00.0" voided="0" uuid="9c067348-5bf2-4050-b824-0aa009436ed6" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
     <concept_name concept_name_id="120001" concept_id="1001" name="Emergency" locale="en" creator="1" date_created="2022-02-02 14:40:00.0" voided="0" uuid="8c067348-5bf2-4050-b824-0aa009436kl0" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
     <concept_name concept_name_id="120003" concept_id="1002" name="Urgent" locale="en" creator="1" date_created="2022-02-02 14:40:00.0" voided="0" uuid="8j067348-6bf2-4050-b824-0aa009436kl6" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
     <concept_set concept_set_id="1" concept_set="1000" concept_id="1001" sort_weight="0" date_created="2022-02-02 14:40:00.0" creator="1" uuid="78b910bd-298c-4ecf-a632-661ae2f886bf"/>

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest_visitInitialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest_visitInitialDataset.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<dataset>
+    <visit_type visit_type_id="1" name="Test visit type" description="This is a test description" creator="1" date_created="2022-02-08 05:20:00.0" retired="false" uuid="hj898a34-1ade-11e1-9c71-00248140a5eb"/>
+    <visit visit_id="101" patient_id="100" visit_type_id="1" date_started="2022-02-07 02:10:00.0" creator="1" date_created="2022-02-07 02:10:00.0" voided="0" uuid="j848b0c0-1ade-11e1-9c71-00248140a6eb" />
+</dataset>

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/visitQueueEntryDaoTest_initialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/visitQueueEntryDaoTest_initialDataset.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<dataset>
+    <visit_queue_entries visit_queue_entry_id="1" visit_id="101" queue_entry_id="1" creator="1"
+                         date_created="2022-02-02 16:38:56.0" voided="false" uuid="5eb8fe43-2813-4kbc-80dc-2e5d30252cc3"/>
+
+    <!--Voided Visit Queue entry -->
+    <visit_queue_entries visit_queue_entry_id="2" visit_id="101" queue_entry_id="1" creator="1"
+                         date_created="2022-02-02 16:38:56.0" voided="true" voided_by="1" date_voided="2022-02-08 10:38:56.0" void_reason="Entered in error" uuid="4eb8fe43-2813-4kbc-80dc-2e5d30252cc6"/>
+</dataset>

--- a/api/src/test/resources/org/openmrs/module/queue/validators/QueueEntryValidatorTest_globalPropertyInitialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/validators/QueueEntryValidatorTest_globalPropertyInitialDataset.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<dataset>
+    <global_property property="queue.statusConceptSetName" property_value="Queue Status"
+                     uuid="6eb8fe43-2813-4kbc-80dc-2e5d30252cc9"/>
+    <global_property property="queue.priorityConceptSetName" property_value="Queue Priority"
+                     uuid="9eb8fe58-2813-4kbc-80dc-2e5d30252cf9"/>
+    <global_property property="queue.serviceConceptSetName" property_value="Queue Service"
+                     uuid="8eb8fe90-2813-4kbc-80dc-2e9d30252cc9"/>
+</dataset>

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueCountSubResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueCountSubResource.java
@@ -1,0 +1,115 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.resources;
+
+import java.util.Collections;
+
+import org.openmrs.module.queue.model.Queue;
+import org.openmrs.module.queue.web.resources.response.QueueCount;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
+import org.openmrs.module.webservices.rest.web.annotation.SubResource;
+import org.openmrs.module.webservices.rest.web.representation.CustomRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+/**
+ * Probably, this sub-resource is unnecessary, the idea is; with a searchHandler -
+ * QueueCountSearchHandler, I can achieve the following URL formats; /ws/rest/v1/queue/<UUID>/count
+ * - returns the count of queue entries for the specified resource
+ * /ws/rest/v1/queue/<UUID>/count?status=Waiting for Service Queue Count
+ * /ws/rest/v1/queue/<UUID>/count?status=With Service /ws/rest/v1/queue/<UUID>/count?status=Waiting
+ * For Service&v=custom:(count) -returns only the count.
+ */
+@SuppressWarnings("unused")
+@SubResource(parent = QueueResource.class, path = "count", supportedClass = QueueCount.class, supportedOpenmrsVersions = {
+        "2.0 - 2.*" })
+public class QueueCountSubResource extends DelegatingSubResource<QueueCount, Queue, QueueResource> {
+	
+	@Override
+	public Queue getParent(QueueCount queueCount) {
+		return queueCount.getQueue();
+	}
+	
+	@Override
+	public void setParent(QueueCount queueCount, Queue queue) {
+		queueCount.setQueue(queue);
+	}
+	
+	@Override
+	public PageableResult doGetAll(Queue queue, RequestContext requestContext) throws ResponseException {
+		return new NeedsPaging<>(Collections.singletonList(new QueueCount(queue, queue.getQueueEntries().size())),
+		        requestContext);
+	}
+	
+	@Override
+	public QueueCount getByUniqueId(String s) {
+		throw new ResourceDoesNotSupportOperationException();
+	}
+	
+	@Override
+	protected void delete(QueueCount queueCount, String s, RequestContext requestContext) throws ResponseException {
+		throw new ResourceDoesNotSupportOperationException();
+	}
+	
+	@Override
+	public QueueCount newDelegate() {
+		return new QueueCount();
+	}
+	
+	@Override
+	public QueueCount save(QueueCount queueCount) {
+		throw new ResourceDoesNotSupportOperationException();
+	}
+	
+	@Override
+	public void purge(QueueCount queueCount, RequestContext requestContext) throws ResponseException {
+		throw new ResourceDoesNotSupportOperationException();
+	}
+	
+	@Override
+	public DelegatingResourceDescription getRepresentationDescription(Representation representation) {
+		DelegatingResourceDescription resourceDescription = new DelegatingResourceDescription();
+		if (representation instanceof CustomRepresentation) {
+			resourceDescription = null;
+		} else if (representation instanceof DefaultRepresentation) {
+			resourceDescription.addProperty("count");
+			resourceDescription.addProperty("display");
+		} else if (representation instanceof RefRepresentation) {
+			resourceDescription.addProperty("count");
+			resourceDescription.addProperty("display");
+			resourceDescription.addProperty("queue", Representation.REF);
+		} else if (representation instanceof FullRepresentation) {
+			resourceDescription.addProperty("count");
+			resourceDescription.addProperty("display");
+			resourceDescription.addProperty("queue", Representation.FULL);
+		}
+		return resourceDescription;
+	}
+	
+	@PropertyGetter("display")
+	public String getDisplay(QueueCount queueCount) {
+		//Display queue name
+		return queueCount.getQueue().getName();
+	}
+	
+	@Override
+	public String getResourceVersion() {
+		return "2.3";
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntryCountSubResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntryCountSubResource.java
@@ -9,10 +9,12 @@
  */
 package org.openmrs.module.queue.web.resources;
 
-import java.util.Collections;
+import java.util.Arrays;
 
 import org.openmrs.module.queue.model.Queue;
-import org.openmrs.module.queue.web.resources.response.QueueCount;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.openmrs.module.queue.web.resources.custom.response.GenericSingleObjectResult;
+import org.openmrs.module.queue.web.resources.custom.response.PropValue;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
 import org.openmrs.module.webservices.rest.web.annotation.SubResource;
@@ -24,7 +26,6 @@ import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubResource;
-import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
@@ -37,48 +38,48 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
  * For Service&v=custom:(count) -returns only the count.
  */
 @SuppressWarnings("unused")
-@SubResource(parent = QueueResource.class, path = "count", supportedClass = QueueCount.class, supportedOpenmrsVersions = {
+@SubResource(parent = QueueResource.class, path = "count", supportedClass = QueueEntry.class, supportedOpenmrsVersions = {
         "2.0 - 2.*" })
-public class QueueCountSubResource extends DelegatingSubResource<QueueCount, Queue, QueueResource> {
+public class QueueEntryCountSubResource extends DelegatingSubResource<QueueEntry, Queue, QueueResource> {
 	
 	@Override
-	public Queue getParent(QueueCount queueCount) {
-		return queueCount.getQueue();
+	public Queue getParent(QueueEntry queueEntryCount) {
+		return queueEntryCount.getQueue();
 	}
 	
 	@Override
-	public void setParent(QueueCount queueCount, Queue queue) {
-		queueCount.setQueue(queue);
+	public void setParent(QueueEntry queueEntryCount, Queue queue) {
+		queueEntryCount.setQueue(queue);
 	}
 	
 	@Override
 	public PageableResult doGetAll(Queue queue, RequestContext requestContext) throws ResponseException {
-		return new NeedsPaging<>(Collections.singletonList(new QueueCount(queue, queue.getQueueEntries().size())),
-		        requestContext);
+		return new GenericSingleObjectResult(Arrays.asList(new PropValue("queueName", queue.getName()),
+		    new PropValue("queueEntriesCount", queue.getQueueEntries().size())));
 	}
 	
 	@Override
-	public QueueCount getByUniqueId(String s) {
+	public QueueEntry getByUniqueId(String s) {
 		throw new ResourceDoesNotSupportOperationException();
 	}
 	
 	@Override
-	protected void delete(QueueCount queueCount, String s, RequestContext requestContext) throws ResponseException {
+	protected void delete(QueueEntry queueEntryCount, String s, RequestContext requestContext) throws ResponseException {
 		throw new ResourceDoesNotSupportOperationException();
 	}
 	
 	@Override
-	public QueueCount newDelegate() {
-		return new QueueCount();
+	public QueueEntry newDelegate() {
+		return new QueueEntry();
 	}
 	
 	@Override
-	public QueueCount save(QueueCount queueCount) {
+	public QueueEntry save(QueueEntry queueEntry) {
 		throw new ResourceDoesNotSupportOperationException();
 	}
 	
 	@Override
-	public void purge(QueueCount queueCount, RequestContext requestContext) throws ResponseException {
+	public void purge(QueueEntry queueEntry, RequestContext requestContext) throws ResponseException {
 		throw new ResourceDoesNotSupportOperationException();
 	}
 	
@@ -103,9 +104,9 @@ public class QueueCountSubResource extends DelegatingSubResource<QueueCount, Que
 	}
 	
 	@PropertyGetter("display")
-	public String getDisplay(QueueCount queueCount) {
+	public String getDisplay(QueueEntry queueEntry) {
 		//Display queue name
-		return queueCount.getQueue().getName();
+		return queueEntry.getQueue().getName();
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntrySubResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntrySubResource.java
@@ -21,6 +21,7 @@ import org.openmrs.module.queue.model.Queue;
 import org.openmrs.module.queue.model.QueueEntry;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
 import org.openmrs.module.webservices.rest.web.annotation.SubResource;
 import org.openmrs.module.webservices.rest.web.representation.CustomRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
@@ -32,6 +33,7 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceD
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingSubResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @SuppressWarnings("unused")
@@ -85,6 +87,30 @@ public class QueueEntrySubResource extends DelegatingSubResource<QueueEntry, Que
 	}
 	
 	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription description = new DelegatingResourceDescription();
+		description.addProperty("status");
+		description.addProperty("priority");
+		description.addProperty("priorityComment");
+		description.addProperty("service");
+		description.addProperty("patient");
+		description.addProperty("sortWeight");
+		description.addProperty("startedAt");
+		description.addProperty("locationWaitingFor");
+		description.addProperty("providerWaitingFor");
+		return description;
+	}
+	
+	@Override
+	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription description = new DelegatingResourceDescription();
+		description.addProperty("priorityComment");
+		description.addProperty("sortWeight");
+		description.addProperty("endedAt");
+		return description;
+	}
+	
+	@Override
 	public DelegatingResourceDescription getRepresentationDescription(Representation representation) {
 		DelegatingResourceDescription resourceDescription = new DelegatingResourceDescription();
 		if (representation instanceof RefRepresentation) {
@@ -134,6 +160,12 @@ public class QueueEntrySubResource extends DelegatingSubResource<QueueEntry, Que
 		resourceDescription.addProperty("sortWeight");
 		resourceDescription.addProperty("startedAt");
 		resourceDescription.addProperty("endedAt");
+	}
+	
+	@PropertyGetter("display")
+	public String getDisplay(QueueEntry queueEntry) {
+		//Display patient name
+		return queueEntry.getPatient().getPerson().getPersonName().getFullName();
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueResource.java
@@ -32,6 +32,7 @@ import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResou
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
 @SuppressWarnings("unused")
@@ -105,6 +106,20 @@ public class QueueResource extends DelegatingCrudResource<Queue> {
 		resourceDescription.addProperty("display");
 		resourceDescription.addProperty("name");
 		resourceDescription.addProperty("description");
+	}
+	
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription resourceDescription = new DelegatingResourceDescription();
+		resourceDescription.addProperty("name");
+		resourceDescription.addProperty("description");
+		resourceDescription.addProperty("location");
+		return resourceDescription;
+	}
+	
+	@Override
+	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
+		return this.getCreatableProperties();
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/VisitQueueEntryResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/VisitQueueEntryResource.java
@@ -27,11 +27,16 @@ import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 
+/**
+ * By convention, resource names should use exclusively lowercase letters. Similarly, dashes (-) are
+ * conventionally used in place of underscores (_).
+ */
 @SuppressWarnings("unused")
 @Resource(name = RestConstants.VERSION_1
-        + "/visit_queue_entry", supportedClass = VisitQueueEntry.class, supportedOpenmrsVersions = { "2.0 - 2.*" })
+        + "/visit-queue-entry", supportedClass = VisitQueueEntry.class, supportedOpenmrsVersions = { "2.0 - 2.*" })
 public class VisitQueueEntryResource extends DelegatingCrudResource<VisitQueueEntry> {
 	
 	private final VisitQueueEntryService visitQueueEntryService;
@@ -68,6 +73,14 @@ public class VisitQueueEntryResource extends DelegatingCrudResource<VisitQueueEn
 	@Override
 	public void purge(VisitQueueEntry visitQueueEntry, RequestContext requestContext) throws ResponseException {
 		
+	}
+	
+	@Override
+	public DelegatingResourceDescription getCreatableProperties() throws ResourceDoesNotSupportOperationException {
+		DelegatingResourceDescription resourceDescription = new DelegatingResourceDescription();
+		resourceDescription.addProperty("visit");
+		resourceDescription.addProperty("queueEntry");
+		return resourceDescription;
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/VisitQueueEntryResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/VisitQueueEntryResource.java
@@ -1,0 +1,106 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.resources;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.api.VisitQueueEntryService;
+import org.openmrs.module.queue.model.VisitQueueEntry;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.CustomRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+@SuppressWarnings("unused")
+@Resource(name = RestConstants.VERSION_1
+        + "/visit_queue_entry", supportedClass = VisitQueueEntry.class, supportedOpenmrsVersions = { "2.0 - 2.*" })
+public class VisitQueueEntryResource extends DelegatingCrudResource<VisitQueueEntry> {
+	
+	private final VisitQueueEntryService visitQueueEntryService;
+	
+	public VisitQueueEntryResource() {
+		this.visitQueueEntryService = Context.getService(VisitQueueEntryService.class);
+	}
+	
+	@Override
+	public VisitQueueEntry getByUniqueId(@NotNull String uuid) {
+		Optional<VisitQueueEntry> visitQueueEntryOptional = this.visitQueueEntryService.getVisitQueueEntryByUuid(uuid);
+		if (!visitQueueEntryOptional.isPresent()) {
+			throw new ObjectNotFoundException("Could not find visit queue entry with uuid " + uuid);
+		}
+		return visitQueueEntryOptional.get();
+	}
+	
+	@Override
+	protected void delete(VisitQueueEntry visitQueueEntry, String voidReason, RequestContext requestContext)
+	        throws ResponseException {
+		this.visitQueueEntryService.voidVisitQueueEntry(visitQueueEntry.getUuid(), voidReason);
+	}
+	
+	@Override
+	public VisitQueueEntry newDelegate() {
+		return new VisitQueueEntry();
+	}
+	
+	@Override
+	public VisitQueueEntry save(VisitQueueEntry visitQueueEntry) {
+		return this.visitQueueEntryService.createVisitQueueEntry(visitQueueEntry);
+	}
+	
+	@Override
+	public void purge(VisitQueueEntry visitQueueEntry, RequestContext requestContext) throws ResponseException {
+		
+	}
+	
+	@Override
+	public DelegatingResourceDescription getRepresentationDescription(Representation representation) {
+		DelegatingResourceDescription description = new DelegatingResourceDescription();
+		if (representation instanceof RefRepresentation) {
+			this.addSharedResourceDescriptionProperties(description);
+			description.addProperty("visit", Representation.REF);
+			description.addProperty("queueEntry", Representation.REF);
+			description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+		} else if (representation instanceof DefaultRepresentation) {
+			this.addSharedResourceDescriptionProperties(description);
+			description.addProperty("visit", Representation.DEFAULT);
+			description.addProperty("queueEntry", Representation.DEFAULT);
+			description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+		} else if (representation instanceof FullRepresentation) {
+			this.addSharedResourceDescriptionProperties(description);
+			description.addProperty("visit", Representation.FULL);
+			description.addProperty("queueEntry", Representation.FULL);
+			description.addProperty("auditInfo");
+		} else if (representation instanceof CustomRepresentation) {
+			description = null;
+		}
+		return description;
+	}
+	
+	private void addSharedResourceDescriptionProperties(DelegatingResourceDescription resourceDescription) {
+		resourceDescription.addSelfLink();
+		resourceDescription.addProperty("uuid");
+	}
+	
+	@Override
+	public String getResourceVersion() {
+		return "2.3";
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/VisitQueueEntryResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/VisitQueueEntryResource.java
@@ -72,7 +72,7 @@ public class VisitQueueEntryResource extends DelegatingCrudResource<VisitQueueEn
 	
 	@Override
 	public void purge(VisitQueueEntry visitQueueEntry, RequestContext requestContext) throws ResponseException {
-		
+		this.visitQueueEntryService.purgeQueueEntry(visitQueueEntry);
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/custom/response/GenericSingleObjectResult.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/custom/response/GenericSingleObjectResult.java
@@ -1,0 +1,45 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.resources.custom.response;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.web.resource.api.Converter;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenericSingleObjectResult implements PageableResult {
+	
+	private List<PropValue> propValues;
+	
+	@Override
+	public SimpleObject toSimpleObject(Converter<?> converter) throws ResponseException {
+		SimpleObject ret = new SimpleObject();
+		this.propValues.forEach(propValue -> ret.add(propValue.getProperty(), propValue.getValue()));
+		return ret;
+	}
+	
+	public void add(@NotNull String property, @NotNull Object value) {
+		if (propValues == null) {
+			this.propValues = new ArrayList<>();
+		}
+		this.propValues.add(new PropValue(property, value));
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/custom/response/PropValue.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/custom/response/PropValue.java
@@ -7,32 +7,23 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.queue.web.resources.response;
+package org.openmrs.module.queue.web.resources.custom.response;
 
 import java.io.Serializable;
-import java.util.UUID;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.openmrs.module.queue.model.Queue;
 
+/**
+ * Wrapper data class for property & value
+ */
 @Data
-@NoArgsConstructor
 @AllArgsConstructor
-public class QueueCount implements Serializable {
+public class PropValue implements Serializable {
 	
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 45L;
 	
-	private String uuid;
+	private String property;
 	
-	private Queue queue;
-	
-	private int count;
-	
-	public QueueCount(Queue queue, int count) {
-		this.uuid = String.valueOf(UUID.randomUUID());
-		this.queue = queue;
-		this.count = count;
-	}
+	private Object value;
 }

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/response/QueueCount.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/response/QueueCount.java
@@ -1,0 +1,38 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.resources.response;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.openmrs.module.queue.model.Queue;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QueueCount implements Serializable {
+	
+	private static final long serialVersionUID = 1L;
+	
+	private String uuid;
+	
+	private Queue queue;
+	
+	private int count;
+	
+	public QueueCount(Queue queue, int count) {
+		this.uuid = String.valueOf(UUID.randomUUID());
+		this.queue = queue;
+		this.count = count;
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/search/handlers/QueueCountSearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/search/handlers/QueueCountSearchHandler.java
@@ -1,0 +1,72 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.resources.search.handlers;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.api.QueueEntryService;
+import org.openmrs.module.queue.api.QueueService;
+import org.openmrs.module.queue.model.Queue;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.openmrs.module.queue.web.resources.response.QueueCount;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchConfig;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchQuery;
+import org.openmrs.module.webservices.rest.web.resource.api.SubResourceSearchHandler;
+import org.openmrs.module.webservices.rest.web.resource.impl.EmptySearchResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueueCountSearchHandler implements SubResourceSearchHandler {
+	
+	private final static SearchConfig SEARCH_CONFIG = new SearchConfig("default", RestConstants.VERSION_1 + "/queue/count",
+	        Collections.singletonList("2.0 - 2.*"),
+	        new SearchQuery.Builder("Allows you to find queue entries by status").withOptionalParameters("status").build());
+	
+	@Override
+	public PageableResult search(String parentUuid, RequestContext requestContext) throws ResponseException {
+		String queueEntryStatus = requestContext.getParameter("status");
+		
+		if (StringUtils.isBlank(queueEntryStatus) || StringUtils.isBlank(parentUuid)) {
+			return new EmptySearchResult();
+		}
+		Collection<QueueEntry> queueEntries = Context.getService(QueueEntryService.class)
+		        .searchQueueEntries(queueEntryStatus, false);
+		QueueCount queueCount = new QueueCount(getParentQueue(parentUuid), queueEntries.size());
+		return new NeedsPaging<>(new ArrayList<>(Collections.singletonList(queueCount)), requestContext);
+	}
+	
+	@Override
+	public SearchConfig getSearchConfig() {
+		return SEARCH_CONFIG;
+	}
+	
+	@Override
+	public PageableResult search(RequestContext requestContext) throws ResponseException {
+		throw new UnsupportedOperationException("Cannot search for queue entries without parent queue");
+	}
+	
+	private Queue getParentQueue(@NotNull String parentUuid) {
+		Optional<Queue> queue = Context.getService(QueueService.class).getQueueByUuid(parentUuid);
+		return queue.orElse(null);
+	}
+	
+}

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/search/handlers/QueueEntrySearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/search/handlers/QueueEntrySearchHandler.java
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.resources.search.handlers;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.api.QueueEntryService;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchConfig;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchQuery;
+import org.openmrs.module.webservices.rest.web.resource.api.SubResourceSearchHandler;
+import org.openmrs.module.webservices.rest.web.resource.impl.EmptySearchResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueueEntrySearchHandler implements SubResourceSearchHandler {
+	
+	private final static SearchConfig SEARCH_CONFIG = new SearchConfig("default", RestConstants.VERSION_1 + "/queue/entry",
+	        Collections.singletonList("2.0 - 2.*"),
+	        new SearchQuery.Builder("Allows you to find queue entries by status").withOptionalParameters("status").build());
+	
+	@Override
+	public PageableResult search(String parentUuid, RequestContext requestContext) throws ResponseException {
+		String status = requestContext.getParameter("status");
+		
+		if (StringUtils.isBlank(status) || StringUtils.isBlank(parentUuid)) {
+			return new EmptySearchResult();
+		}
+		Collection<QueueEntry> queueEntries = Context.getService(QueueEntryService.class).searchQueueEntries(status, false);
+		return new NeedsPaging<>(new ArrayList<>(queueEntries), requestContext);
+	}
+	
+	@Override
+	public SearchConfig getSearchConfig() {
+		return SEARCH_CONFIG;
+	}
+	
+	@Override
+	public PageableResult search(RequestContext requestContext) throws ResponseException {
+		throw new UnsupportedOperationException("Cannot search for queue entries without parent queue");
+	}
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -54,5 +54,20 @@
     </messages>
     <!-- /Internationalization -->
 
+    <globalProperty>
+        <property>${project.parent.artifactId}.statusConceptSetName</property>
+        <defaultValue>Queue Status</defaultValue>
+        <description>Set status conceptSet name</description>
+    </globalProperty>
+    <globalProperty>
+        <property>${project.parent.artifactId}.priorityConceptSetName</property>
+        <defaultValue>Queue Priority</defaultValue>
+        <description>Set priority conceptSet name</description>
+    </globalProperty>
+    <globalProperty>
+        <property>${project.parent.artifactId}.serviceConceptSetName</property>
+        <defaultValue>Queue Service</defaultValue>
+        <description>Set service conceptSet name</description>
+    </globalProperty>
 </module>
 

--- a/omod/src/test/java/org/openmrs/module/queue/web/resources/VisitQueueEntryResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/queue/web/resources/VisitQueueEntryResourceTest.java
@@ -1,0 +1,79 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.resources;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.api.VisitQueueEntryService;
+import org.openmrs.module.queue.model.VisitQueueEntry;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public class VisitQueueEntryResourceTest extends BaseQueueResourceTest<VisitQueueEntry, VisitQueueEntryResource> {
+	
+	private static final String VISIT_QUEUE_ENTRY_UUID = "6hje567a-fca0-11e5-9e59-08002719a7";
+	
+	@Mock
+	private VisitQueueEntryService visitQueueEntryService;
+	
+	private VisitQueueEntry visitQueueEntry;
+	
+	@Before
+	public void setup() {
+		this.prepareMocks();
+		visitQueueEntry = mock(VisitQueueEntry.class);
+		
+		when(visitQueueEntry.getUuid()).thenReturn(VISIT_QUEUE_ENTRY_UUID);
+		when(Context.getService(VisitQueueEntryService.class)).thenReturn(visitQueueEntryService);
+		
+		this.setResource(new VisitQueueEntryResource());
+		this.setObject(visitQueueEntry);
+	}
+	
+	@Test
+	public void shouldGetQueueEntryService() {
+		assertThat(visitQueueEntryService, notNullValue());
+	}
+	
+	@Test
+	public void shouldGetResourceByUniqueUuid() {
+		when(visitQueueEntryService.getVisitQueueEntryByUuid(VISIT_QUEUE_ENTRY_UUID))
+		        .thenReturn(Optional.of(visitQueueEntry));
+		
+		VisitQueueEntry result = getResource().getByUniqueId(VISIT_QUEUE_ENTRY_UUID);
+		assertThat(result, notNullValue());
+		assertThat(result.getUuid(), is(VISIT_QUEUE_ENTRY_UUID));
+	}
+	
+	@Test
+	public void shouldCreateNewResource() {
+		when(visitQueueEntryService.createVisitQueueEntry(getObject())).thenReturn(getObject());
+		
+		VisitQueueEntry newlyCreatedObject = getResource().save(getObject());
+		assertThat(newlyCreatedObject, notNullValue());
+		assertThat(newlyCreatedObject.getUuid(), is(VISIT_QUEUE_ENTRY_UUID));
+	}
+	
+	@Test
+	public void shouldInstantiateNewDelegate() {
+		assertThat(getResource().newDelegate(), notNullValue());
+	}
+}


### PR DESCRIPTION
This PR wraps up CRUD operation implementation for the 3 resources and subresources, additionally, it adds basic(commons) validations rule which includes;
- `queueEntry.status` concept should be a member of the queue status concept set configured via GP; this applies to queue priority and queue service
- `queue.name` - not null
- `queue.location` - should exists, in future only location tag with queue(specific use case) 
- ...

Search Operations
-  Implement search by queue status - `/queue/<parentUuid>/entry?status=Waiting For Service`
- Implement count by status - `queue/<UUID>/count?status=Waiting For Service`
- ...

At this point, I think we got a working MVP of the queue module. Maybe one or two logic/features are missing. Ready for testing/usage.