### PR TITLE
Filter visitQueueEntries by status and service

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
@@ -60,13 +60,13 @@ public interface QueueEntryService {
 	void purgeQueueEntry(@NotNull QueueEntry queueEntry) throws APIException;
 	
 	/**
-	 * Search for queue entries by status
+	 * Search for queue entries by conceptStatus
 	 *
-	 * @param status queue entry status
+	 * @param conceptStatus queue entry conceptStatus
 	 * @param includeVoided include/exclude voided queue entries
 	 * @return {@link java.util.Collection} of queue entries with the specified statuses
 	 */
-	Collection<QueueEntry> searchQueueEntries(@NotNull String status, boolean includeVoided);
+	Collection<QueueEntry> searchQueueEntriesByConceptStatus(@NotNull String conceptStatus, boolean includeVoided);
 	
 	/**
 	 * Gets count of queue entries by status

--- a/api/src/main/java/org/openmrs/module/queue/api/VisitQueueEntryService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/VisitQueueEntryService.java
@@ -43,6 +43,16 @@ public interface VisitQueueEntryService {
 	Collection<VisitQueueEntry> findAllVisitQueueEntries();
 	
 	/**
+	 * Find visitQueueEntries by service and status i.e. Find patients waiting for(status) certain
+	 * service
+	 *
+	 * @param status concept name for queueEntry status
+	 * @param service concept name for queue service
+	 * @return {@link Collection} visitQueueEntries matching specified parameters
+	 */
+	Collection<VisitQueueEntry> findVisitQueueEntries(String status, String service);
+	
+	/**
 	 * Voids a visit queue entry record
 	 *
 	 * @param visitQueueEntryUuid uuid of the queue entry to be voided

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/QueueEntryDao.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/QueueEntryDao.java
@@ -15,24 +15,29 @@ import java.util.Collection;
 
 import org.openmrs.Auditable;
 import org.openmrs.OpenmrsObject;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.module.queue.model.QueueEntry;
 
 public interface QueueEntryDao<Q extends OpenmrsObject & Auditable> extends BaseQueueDao<Q> {
 	
 	/**
-	 * Searches queue entries by status
+	 * Searches queue entries by conceptStatus
 	 *
-	 * @param status the queueEntry status
+	 * @param conceptStatus the queueEntry conceptStatus
 	 * @param includeVoided Include/exclude voided queue entries
-	 * @return {@link java.util.Collection} of queue entries with the specified status
+	 * @return {@link java.util.Collection} of queue entries with the specified conceptStatus
 	 */
-	Collection<QueueEntry> SearchQueueEntries(@NotNull String status, boolean includeVoided);
+	Collection<QueueEntry> SearchQueueEntriesByConceptStatus(@NotNull String conceptStatus, ConceptNameType conceptNameType,
+	        boolean localePreferred, boolean includeVoided);
 	
 	/**
 	 * Gets count of queue entries by given status
 	 *
-	 * @param status the queue entry status
+	 * @param conceptStatus the queue entry status
+	 * @param conceptNameType the conceptNameType e.g. FULLY_SPECIFIED
+	 * @param localePreferred locale preferred either true or false
 	 * @return {@link java.lang.Long} count of queue entries by status
 	 */
-	Long getQueueEntriesCountByStatus(@NotNull String status);
+	Long getQueueEntriesCountByConceptStatus(@NotNull String conceptStatus, ConceptNameType conceptNameType,
+	        boolean localePreferred);
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/VisitQueueEntryDao.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/VisitQueueEntryDao.java
@@ -9,7 +9,20 @@
  */
 package org.openmrs.module.queue.api.dao;
 
+import java.util.Collection;
+
 import org.openmrs.Auditable;
 import org.openmrs.OpenmrsObject;
+import org.openmrs.module.queue.model.VisitQueueEntry;
 
-public interface VisitQueueEntryDao<Q extends OpenmrsObject & Auditable> extends BaseQueueDao<Q> {}
+public interface VisitQueueEntryDao<Q extends OpenmrsObject & Auditable> extends BaseQueueDao<Q> {
+	
+	/**
+	 * Finds {@link VisitQueueEntry} by status and service.
+	 *
+	 * @param status conceptName for queueEntry status concept.
+	 * @param service conceptName for queue service concept.
+	 * @return {@link Collection} of visitQueueEntries matching specified parameters.
+	 */
+	Collection<VisitQueueEntry> findVisitQueueEntriesByStatusAndService(String status, String service);
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/VisitQueueEntryDao.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/VisitQueueEntryDao.java
@@ -13,16 +13,18 @@ import java.util.Collection;
 
 import org.openmrs.Auditable;
 import org.openmrs.OpenmrsObject;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.module.queue.model.VisitQueueEntry;
 
 public interface VisitQueueEntryDao<Q extends OpenmrsObject & Auditable> extends BaseQueueDao<Q> {
 	
 	/**
-	 * Finds {@link VisitQueueEntry} by status and service.
+	 * Finds {@link VisitQueueEntry} by conceptStatus and conceptService.
 	 *
-	 * @param status conceptName for queueEntry status concept.
-	 * @param service conceptName for queue service concept.
+	 * @param conceptStatus conceptName for queueEntry conceptStatus concept.
+	 * @param conceptService conceptName for queue conceptService concept.
 	 * @return {@link Collection} of visitQueueEntries matching specified parameters.
 	 */
-	Collection<VisitQueueEntry> findVisitQueueEntriesByStatusAndService(String status, String service);
+	Collection<VisitQueueEntry> findVisitQueueEntriesByConceptStatusAndConceptService(String conceptStatus,
+	        String conceptService, ConceptNameType conceptNameType, boolean localePreferred);
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/AbstractBaseQueueDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/AbstractBaseQueueDaoImpl.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.criterion.Conjunction;
 import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
@@ -32,6 +33,7 @@ import org.openmrs.ConceptName;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.Retireable;
 import org.openmrs.Voidable;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.module.queue.api.dao.BaseQueueDao;
 
 @Slf4j
@@ -126,8 +128,17 @@ public class AbstractBaseQueueDaoImpl<Q extends OpenmrsObject & Auditable> imple
 	 * @param conceptName Concept name
 	 * @return {@link DetachedCriteria} conceptName subQuery
 	 */
-	protected DetachedCriteria conceptByNameDetachedCriteria(@NotNull String conceptName) {
-		return DetachedCriteria.forClass(ConceptName.class, "cn").add(Restrictions.eq("cn.name", conceptName))
-		        .setProjection(Projections.property("cn.concept"));
+	protected DetachedCriteria conceptByNameDetachedCriteria(@NotNull String conceptName, boolean localePreferred,
+	        ConceptNameType conceptNameType) {
+		DetachedCriteria detachedCriteria = DetachedCriteria.forClass(ConceptName.class, "cn");
+		Conjunction and = Restrictions.conjunction();
+		and.add(Restrictions.eq("cn.name", conceptName));
+		//An option to restrict by localePreferred
+		and.add(Restrictions.eq("cn.localePreferred", localePreferred));
+		and.add(Restrictions.eq("cn.conceptNameType", conceptNameType));
+		
+		detachedCriteria.add(and);
+		detachedCriteria.setProjection(Projections.property("cn.concept"));
+		return detachedCriteria;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/AbstractBaseQueueDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/AbstractBaseQueueDaoImpl.java
@@ -24,7 +24,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.criterion.DetachedCriteria;
+import org.hibernate.criterion.Projections;
+import org.hibernate.criterion.Restrictions;
 import org.openmrs.Auditable;
+import org.openmrs.ConceptName;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.Retireable;
 import org.openmrs.Voidable;
@@ -114,5 +118,16 @@ public class AbstractBaseQueueDaoImpl<Q extends OpenmrsObject & Auditable> imple
 				handleRetireable(criteria);
 			}
 		}
+	}
+	
+	/**
+	 * Creates concept names subQuery
+	 *
+	 * @param conceptName Concept name
+	 * @return {@link DetachedCriteria} conceptName subQuery
+	 */
+	protected DetachedCriteria conceptByNameDetachedCriteria(@NotNull String conceptName) {
+		return DetachedCriteria.forClass(ConceptName.class, "cn").add(Restrictions.eq("cn.name", conceptName))
+		        .setProjection(Projections.property("cn.concept"));
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
@@ -17,6 +17,7 @@ import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Property;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.module.queue.api.dao.QueueEntryDao;
 import org.openmrs.module.queue.model.QueueEntry;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,27 +34,32 @@ public class QueueEntryDaoImpl extends AbstractBaseQueueDaoImpl<QueueEntry> impl
 	}
 	
 	/**
-	 * @see org.openmrs.module.queue.api.dao.QueueEntryDao#SearchQueueEntries(String, boolean)
+	 * @see QueueEntryDao#SearchQueueEntriesByConceptStatus(String, ConceptNameType, boolean, boolean)
 	 */
 	@Override
-	public Collection<QueueEntry> SearchQueueEntries(@NotNull String status, boolean includeVoided) {
+	public Collection<QueueEntry> SearchQueueEntriesByConceptStatus(@NotNull String status, ConceptNameType conceptNameType,
+	        boolean localePreferred, boolean includeVoided) {
 		Criteria criteria = getCurrentSession().createCriteria(QueueEntry.class, "qe");
 		//Include/exclude retired queues
 		includeVoidedObjects(criteria, includeVoided);
-		criteria.add(Property.forName("qe.status").in(conceptByNameDetachedCriteria(status)));
+		criteria.add(
+		    Property.forName("qe.status").in(conceptByNameDetachedCriteria(status, localePreferred, conceptNameType)));
 		
 		return criteria.list();
 	}
 	
 	/**
-	 * @see org.openmrs.module.queue.api.dao.QueueEntryDao#getQueueEntriesCountByStatus(String)
+	 * @see org.openmrs.module.queue.api.dao.QueueEntryDao#getQueueEntriesCountByConceptStatus(String,
+	 *      ConceptNameType, boolean)
 	 */
 	@Override
-	public Long getQueueEntriesCountByStatus(@NotNull String status) {
+	public Long getQueueEntriesCountByConceptStatus(@NotNull String conceptStatus, ConceptNameType conceptNameType,
+	        boolean localePreferred) {
 		Criteria criteria = getCurrentSession().createCriteria(QueueEntry.class, "qe");
 		//Include/exclude retired queues
 		includeVoidedObjects(criteria, false);
-		criteria.add(Property.forName("qe.status").in(conceptByNameDetachedCriteria(status)));
+		criteria.add(Property.forName("qe.status")
+		        .in(conceptByNameDetachedCriteria(conceptStatus, localePreferred, conceptNameType)));
 		criteria.setProjection(Projections.rowCount());
 		
 		return (Long) criteria.uniqueResult();

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
@@ -15,11 +15,8 @@ import java.util.Collection;
 
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
-import org.hibernate.criterion.DetachedCriteria;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Property;
-import org.hibernate.criterion.Restrictions;
-import org.openmrs.ConceptName;
 import org.openmrs.module.queue.api.dao.QueueEntryDao;
 import org.openmrs.module.queue.model.QueueEntry;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +40,7 @@ public class QueueEntryDaoImpl extends AbstractBaseQueueDaoImpl<QueueEntry> impl
 		Criteria criteria = getCurrentSession().createCriteria(QueueEntry.class, "qe");
 		//Include/exclude retired queues
 		includeVoidedObjects(criteria, includeVoided);
-		criteria.add(Property.forName("qe.status").in(conceptStatusDetachedCriteria(status)));
+		criteria.add(Property.forName("qe.status").in(conceptByNameDetachedCriteria(status)));
 		
 		return criteria.list();
 	}
@@ -56,14 +53,9 @@ public class QueueEntryDaoImpl extends AbstractBaseQueueDaoImpl<QueueEntry> impl
 		Criteria criteria = getCurrentSession().createCriteria(QueueEntry.class, "qe");
 		//Include/exclude retired queues
 		includeVoidedObjects(criteria, false);
-		criteria.add(Property.forName("qe.status").in(conceptStatusDetachedCriteria(status)));
+		criteria.add(Property.forName("qe.status").in(conceptByNameDetachedCriteria(status)));
 		criteria.setProjection(Projections.rowCount());
 		
 		return (Long) criteria.uniqueResult();
-	}
-	
-	private DetachedCriteria conceptStatusDetachedCriteria(@NotNull String status) {
-		return DetachedCriteria.forClass(ConceptName.class, "cn").add(Restrictions.eq("cn.name", status))
-		        .setProjection(Projections.property("cn.concept"));
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/VisitQueueEntryDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/VisitQueueEntryDaoImpl.java
@@ -9,18 +9,51 @@
  */
 package org.openmrs.module.queue.api.dao.impl;
 
+import static org.hibernate.criterion.Restrictions.and;
+
+import java.util.Collection;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
+import org.hibernate.criterion.Subqueries;
 import org.openmrs.module.queue.api.dao.VisitQueueEntryDao;
 import org.openmrs.module.queue.model.VisitQueueEntry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
+@SuppressWarnings("unchecked")
 @Repository("queue.VisitQueueEntryDao")
 public class VisitQueueEntryDaoImpl extends AbstractBaseQueueDaoImpl<VisitQueueEntry> implements VisitQueueEntryDao<VisitQueueEntry> {
 	
 	@Autowired
 	public VisitQueueEntryDaoImpl(@Qualifier("sessionFactory") SessionFactory sessionFactory) {
 		super(sessionFactory);
+	}
+	
+	/**
+	 * @see VisitQueueEntryDao#findVisitQueueEntriesByStatusAndService(String, String)
+	 */
+	@Override
+	public Collection<VisitQueueEntry> findVisitQueueEntriesByStatusAndService(String status, String service) {
+		Criteria criteriaVisitQueueEntries = getCurrentSession().createCriteria(VisitQueueEntry.class, "_vqe");
+		includeVoidedObjects(criteriaVisitQueueEntries, false);
+		Criteria criteriaQueueEntries = criteriaVisitQueueEntries.createCriteria("_vqe.queueEntry", "_qe");
+		Criteria criteriaQueue = criteriaQueueEntries.createCriteria("_qe.queue", "_q");
+		
+		if (status != null && service != null) {
+			criteriaQueue
+			        .add(and(Subqueries.propertiesIn(new String[] { "_qe.status" }, conceptByNameDetachedCriteria(status)),
+			            Subqueries.propertiesIn(new String[] { "_q.service" }, conceptByNameDetachedCriteria(service))));
+		} else if (status != null) {
+			criteriaQueue.add(Subqueries.propertiesIn(new String[] { "_qe.status" }, conceptByNameDetachedCriteria(status)));
+		} else if (service != null) {
+			criteriaQueue
+			        .add(Subqueries.propertiesIn(new String[] { "_q.service" }, conceptByNameDetachedCriteria(service)));
+		}
+		
+		return criteriaQueue.list();
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
@@ -19,6 +19,7 @@ import lombok.AccessLevel;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.openmrs.api.APIException;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.queue.api.QueueEntryService;
@@ -85,11 +86,13 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	}
 	
 	/**
-	 * @see org.openmrs.module.queue.api.QueueEntryService#searchQueueEntries(String, boolean)
+	 * @see org.openmrs.module.queue.api.QueueEntryService#searchQueueEntriesByConceptStatus(String,
+	 *      boolean)
 	 */
 	@Override
-	public Collection<QueueEntry> searchQueueEntries(String status, boolean includeVoided) {
-		return this.dao.SearchQueueEntries(status, includeVoided);
+	public Collection<QueueEntry> searchQueueEntriesByConceptStatus(String conceptStatus, boolean includeVoided) {
+		return this.dao.SearchQueueEntriesByConceptStatus(conceptStatus, ConceptNameType.FULLY_SPECIFIED, false,
+		    includeVoided);
 	}
 	
 	/**
@@ -97,6 +100,6 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	 */
 	@Override
 	public Long getQueueEntriesCountByStatus(@NotNull String status) {
-		return this.dao.getQueueEntriesCountByStatus(status);
+		return this.dao.getQueueEntriesCountByConceptStatus(status, ConceptNameType.FULLY_SPECIFIED, false);
 	}
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/VisitQueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/VisitQueueEntryServiceImpl.java
@@ -20,6 +20,7 @@ import lombok.Setter;
 import org.openmrs.Patient;
 import org.openmrs.Visit;
 import org.openmrs.api.APIException;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.queue.api.QueueEntryService;
@@ -74,7 +75,9 @@ public class VisitQueueEntryServiceImpl extends BaseOpenmrsService implements Vi
 	
 	@Override
 	public Collection<VisitQueueEntry> findVisitQueueEntries(String status, String service) {
-		return dao.findVisitQueueEntriesByStatusAndService(status, service);
+		//Restrict to fully_specified concept names
+		return dao.findVisitQueueEntriesByConceptStatusAndConceptService(status, service, ConceptNameType.FULLY_SPECIFIED,
+		    false);
 	}
 	
 	@Override

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/VisitQueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/VisitQueueEntryServiceImpl.java
@@ -73,6 +73,11 @@ public class VisitQueueEntryServiceImpl extends BaseOpenmrsService implements Vi
 	}
 	
 	@Override
+	public Collection<VisitQueueEntry> findVisitQueueEntries(String status, String service) {
+		return dao.findVisitQueueEntriesByStatusAndService(status, service);
+	}
+	
+	@Override
 	public void voidVisitQueueEntry(@NotNull String visitQueueEntryUuid, String voidReason) {
 		this.dao.get(visitQueueEntryUuid).ifPresent(visitQueueEntry -> {
 			visitQueueEntry.setVoided(true);

--- a/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
@@ -24,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openmrs.Concept;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.module.queue.api.dao.QueueEntryDao;
 import org.openmrs.module.queue.api.impl.QueueEntryServiceImpl;
 import org.openmrs.module.queue.model.QueueEntry;
@@ -77,7 +78,6 @@ public class QueueEntryServiceTest {
 	public void shouldCreateNewQueueEntryRecord() {
 		QueueEntry queueEntry = mock(QueueEntry.class);
 		Concept conceptStatus = mock(Concept.class);
-		Concept conceptService = mock(Concept.class);
 		Concept conceptPriority = mock(Concept.class);
 		
 		when(queueEntry.getQueueEntryId()).thenReturn(QUEUE_ENTRY_ID);
@@ -112,14 +112,16 @@ public class QueueEntryServiceTest {
 	
 	@Test
 	public void shouldReturnCountOfQueueEntriesByStatus() {
-		when(dao.getQueueEntriesCountByStatus(QUEUE_ENTRY_STATUS)).thenReturn(1L);
+		when(dao.getQueueEntriesCountByConceptStatus(QUEUE_ENTRY_STATUS, ConceptNameType.FULLY_SPECIFIED, false))
+		        .thenReturn(1L);
 		
 		assertThat(queueEntryService.getQueueEntriesCountByStatus(QUEUE_ENTRY_STATUS), is(1L));
 	}
 	
 	@Test
 	public void shouldReturnZeroForBadGivenStatus() {
-		when(dao.getQueueEntriesCountByStatus(BAD_QUEUE_ENTRY_STATUS)).thenReturn(0L);
+		when(dao.getQueueEntriesCountByConceptStatus(BAD_QUEUE_ENTRY_STATUS, ConceptNameType.FULLY_SPECIFIED, false))
+		        .thenReturn(0L);
 		
 		assertThat(queueEntryService.getQueueEntriesCountByStatus(QUEUE_ENTRY_STATUS), is(0L));
 	}

--- a/api/src/test/java/org/openmrs/module/queue/api/dao/QueueDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/dao/QueueDaoTest.java
@@ -120,14 +120,14 @@ public class QueueDaoTest extends BaseModuleContextSensitiveTest {
 	public void shouldFindAllQueues() {
 		Collection<Queue> queues = dao.findAll();
 		assertThat(queues.isEmpty(), is(false));
-		assertThat(queues, hasSize(1));
+		assertThat(queues, hasSize(2));
 	}
 	
 	@Test
 	public void shouldFindAllQueuesIncludingRetired() {
 		Collection<Queue> queues = dao.findAll(true);
 		assertThat(queues.isEmpty(), is(false));
-		assertThat(queues, hasSize(2));
+		assertThat(queues, hasSize(3));
 	}
 	
 	@Test
@@ -153,7 +153,7 @@ public class QueueDaoTest extends BaseModuleContextSensitiveTest {
 		List<Queue> queuesByLocation = dao.getAllQueuesByLocation(LOCATION_UUID);
 		
 		assertThat(queuesByLocation, notNullValue());
-		assertThat(queuesByLocation, hasSize(1));
+		assertThat(queuesByLocation, hasSize(2));
 		queuesByLocation.forEach(queue -> assertThat(queue.getLocation().getUuid(), is(LOCATION_UUID)));
 	}
 	
@@ -162,7 +162,7 @@ public class QueueDaoTest extends BaseModuleContextSensitiveTest {
 		List<Queue> queuesByLocation = dao.getAllQueuesByLocation(LOCATION_UUID, true);
 		
 		assertThat(queuesByLocation, notNullValue());
-		assertThat(queuesByLocation, hasSize(2));
+		assertThat(queuesByLocation, hasSize(3));
 		queuesByLocation.forEach(queue -> assertThat(queue.getLocation().getUuid(), is(LOCATION_UUID)));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
@@ -146,14 +146,14 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	public void shouldFindAllQueueEntries() {
 		Collection<QueueEntry> queues = dao.findAll();
 		assertThat(queues.isEmpty(), is(false));
-		assertThat(queues, hasSize(1));
+		assertThat(queues, hasSize(2));
 	}
 	
 	@Test
 	public void shouldFindAllQueueEntriesIncludingRetired() {
 		Collection<QueueEntry> queues = dao.findAll(true);
 		assertThat(queues.isEmpty(), is(false));
-		assertThat(queues, hasSize(2));
+		assertThat(queues, hasSize(3));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Concept;
 import org.openmrs.Patient;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.queue.SpringTestConfiguration;
 import org.openmrs.module.queue.model.Queue;
@@ -197,7 +198,8 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldSearchQueueEntriesByStatus() {
-		Collection<QueueEntry> queueEntries = dao.SearchQueueEntries(QUEUE_ENTRY_STATUS, false);
+		Collection<QueueEntry> queueEntries = dao.SearchQueueEntriesByConceptStatus(QUEUE_ENTRY_STATUS,
+		    ConceptNameType.FULLY_SPECIFIED, false, false);
 		
 		assertThat(queueEntries.isEmpty(), is(false));
 		assertThat(queueEntries, hasSize(1));
@@ -209,7 +211,8 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldSearchQueueEntriesByStatusIncludingVoidedQueueEntries() {
-		Collection<QueueEntry> queueEntries = dao.SearchQueueEntries(QUEUE_ENTRY_STATUS, true);
+		Collection<QueueEntry> queueEntries = dao.SearchQueueEntriesByConceptStatus(QUEUE_ENTRY_STATUS,
+		    ConceptNameType.FULLY_SPECIFIED, false, true);
 		
 		assertThat(queueEntries.isEmpty(), is(false));
 		assertThat(queueEntries, hasSize(2));
@@ -221,7 +224,8 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldCountQueueEntriesByStatus() {
-		Long queueEntriesCountByStatusCount = dao.getQueueEntriesCountByStatus(QUEUE_ENTRY_STATUS);
+		Long queueEntriesCountByStatusCount = dao.getQueueEntriesCountByConceptStatus(QUEUE_ENTRY_STATUS,
+		    ConceptNameType.FULLY_SPECIFIED, false);
 		
 		assertThat(queueEntriesCountByStatusCount, notNullValue());
 		assertThat(queueEntriesCountByStatusCount, is(1L));
@@ -229,7 +233,8 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldZeroCountQueueEntriesByBadStatus() {
-		Long queueEntriesCountByStatusCount = dao.getQueueEntriesCountByStatus(BAD_QUEUE_ENTRY_STATUS);
+		Long queueEntriesCountByStatusCount = dao.getQueueEntriesCountByConceptStatus(BAD_QUEUE_ENTRY_STATUS,
+		    ConceptNameType.FULLY_SPECIFIED, false);
 		
 		assertThat(queueEntriesCountByStatusCount, notNullValue());
 		assertThat(queueEntriesCountByStatusCount, is(0L));

--- a/api/src/test/java/org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Visit;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.queue.SpringTestConfiguration;
 import org.openmrs.module.queue.api.QueueEntryService;
@@ -169,7 +170,8 @@ public class VisitQueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldFindVisitQueueEntriesByWaitingForStatusAndService() {
-		Collection<VisitQueueEntry> result = dao.findVisitQueueEntriesByStatusAndService(WAITING_FOR_STATUS, TRIAGE_SERVICE);
+		Collection<VisitQueueEntry> result = dao.findVisitQueueEntriesByConceptStatusAndConceptService(WAITING_FOR_STATUS,
+		    TRIAGE_SERVICE, ConceptNameType.FULLY_SPECIFIED, false);
 		
 		assertThat(result, notNullValue());
 		assertThat(result, hasSize(1));
@@ -177,8 +179,8 @@ public class VisitQueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldFindVisitQueueEntriesByInServiceStatusAndService() {
-		Collection<VisitQueueEntry> result = dao.findVisitQueueEntriesByStatusAndService(IN_SERVICE_STATUS,
-		    CONSULTATION_SERVICE);
+		Collection<VisitQueueEntry> result = dao.findVisitQueueEntriesByConceptStatusAndConceptService(IN_SERVICE_STATUS,
+		    CONSULTATION_SERVICE, ConceptNameType.FULLY_SPECIFIED, false);
 		
 		assertThat(result, notNullValue());
 		assertThat(result, hasSize(1));
@@ -186,7 +188,8 @@ public class VisitQueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldFilterVisitQueueEntriesByInServiceStatus() {
-		Collection<VisitQueueEntry> result = dao.findVisitQueueEntriesByStatusAndService(IN_SERVICE_STATUS, null);
+		Collection<VisitQueueEntry> result = dao.findVisitQueueEntriesByConceptStatusAndConceptService(IN_SERVICE_STATUS,
+		    null, ConceptNameType.FULLY_SPECIFIED, false);
 		
 		assertThat(result, notNullValue());
 		assertThat(result, hasSize(1));
@@ -194,7 +197,8 @@ public class VisitQueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldFilterVisitQueueEntriesByConsultationService() {
-		Collection<VisitQueueEntry> result = dao.findVisitQueueEntriesByStatusAndService(null, CONSULTATION_SERVICE);
+		Collection<VisitQueueEntry> result = dao.findVisitQueueEntriesByConceptStatusAndConceptService(null,
+		    CONSULTATION_SERVICE, ConceptNameType.FULLY_SPECIFIED, false);
 		
 		assertThat(result, notNullValue());
 		assertThat(result, hasSize(1));
@@ -202,7 +206,8 @@ public class VisitQueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldNotFilterVisitQueueEntriesByServiceAndStatusIfBothAreNull() {
-		Collection<VisitQueueEntry> result = dao.findVisitQueueEntriesByStatusAndService(null, null);
+		Collection<VisitQueueEntry> result = dao.findVisitQueueEntriesByConceptStatusAndConceptService(null, null,
+		    ConceptNameType.FULLY_SPECIFIED, false);
 		
 		assertThat(result, notNullValue());
 		assertThat(result, hasSize(2));

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueDaoTest_initialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueDaoTest_initialDataset.xml
@@ -11,6 +11,9 @@
 <dataset>
     <queue queue_id="1" name="Triage Test Queue" description="This is description" location_id="1" service="2001" creator="1"
            date_created="2022-01-31 00:00:00.0" retired="false" uuid="3eb7fe43-2813-4kbc-80dc-2e5d30252bb5"/>
+    <!-- Consultation queue -->
+    <queue queue_id="3" name="Consultation Queue" description="This is consultation queue description" location_id="1" service="2002" creator="1"
+           date_created="2022-01-31 00:00:00.0" retired="false" uuid="5ob7fe43-2813-4kbc-80dc-2e5d30252bb3"/>
     <!--Retired Queue -->
     <queue queue_id="2" name="Retired Test Queue" service="2001" description="This is description" location_id="1" creator="1"
            date_created="2022-01-31 00:00:00.0" retired="true" date_retired="2022-02-02 16:00:00.0"

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueEntryDaoTest_conceptsInitialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueEntryDaoTest_conceptsInitialDataset.xml
@@ -22,9 +22,12 @@
     <!--A concept set of queue service -->
     <concept concept_id="2000" retired="false" is_set="true" creator="1" date_created="2022-02-02 14:31:00.0" uuid="907eba27-2b38-43e8-91a9-4dfe3956a35t"/>
     <concept concept_id="2001" retired="false" is_set="false" creator="1" date_created="2022-02-02 14:40:00.0" uuid="67b910bd-298c-4ecf-a632-661ae2f446op"/>
+    <concept concept_id="2002" retired="false" is_set="false" creator="1" date_created="2022-03-08 15:40:00.0" uuid="68b910bd-298c-4ecf-a632-661ae2f446op"/>
     <concept_name concept_name_id="893" concept_id="2000" name="Queue Service" locale="en" creator="1" date_created="2022-02-02 14:40:00.0" voided="0" uuid="9cp62348-5bf2-4050-b824-0aa009436ed6" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
     <concept_name concept_name_id="210" concept_id="2001" name="Triage" locale="en" creator="1" date_created="2022-02-02 14:40:00.0" voided="0" uuid="9i667348-5bf2-4050-b824-0aa009436kl0" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
+    <concept_name concept_name_id="211" concept_id="2002" name="Consultation" locale="en" creator="1" date_created="2022-02-02 14:40:00.0" voided="0" uuid="5t747348-5bf2-4050-b824-0aa009436kl0" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
     <concept_set concept_set_id="389000" concept_set="2000" concept_id="2001" sort_weight="0" date_created="2022-02-02 14:40:00.0" creator="1" uuid="470b910bd-298c-4ecf-a632-661ae2f886bf"/>
+    <concept_set concept_set_id="389001" concept_set="2000" concept_id="2002" sort_weight="0" date_created="2022-03-08 15:50:00.0" creator="1" uuid="380b910bd-298c-4ecf-a632-661ae2f886bf"/>
 
     <!--A concept set of queue status -->
     <concept concept_id="3000" retired="false" is_set="true" creator="1" date_created="2022-02-02 14:31:00.0" uuid="303eba27-2b38-43e8-91a9-4dfe3956a78t"/>

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueEntryDaoTest_initialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/QueueEntryDaoTest_initialDataset.xml
@@ -11,6 +11,8 @@
 <dataset>
     <queue_entry queue_entry_id="1"  queue_id="1" patient_id="100" creator="1" priority="1001" status="3001" sort_weight="0"
            date_created="2022-02-02 16:38:56.0" started_at="2022-02-02 16:40:56.0" voided="false" uuid="4eb8fe43-2813-4kbc-80dc-2e5d30252cc6"/>
+    <queue_entry queue_entry_id="3"  queue_id="3" patient_id="100" creator="1" priority="1001" status="3002" sort_weight="0"
+                 date_created="2022-02-02 16:38:56.0" started_at="2022-02-02 16:40:56.0" voided="false" uuid="7ub8fe43-2813-4kbc-80dc-2e5d30252cc5"/>
 
     <!--Voided Queue entry -->
     <queue_entry queue_entry_id="2"  queue_id="2" patient_id="100" creator="1" priority="1001" status="3001" sort_weight="0"

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest_visitInitialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest_visitInitialDataset.xml
@@ -11,4 +11,5 @@
 <dataset>
     <visit_type visit_type_id="1" name="Test visit type" description="This is a test description" creator="1" date_created="2022-02-08 05:20:00.0" retired="false" uuid="hj898a34-1ade-11e1-9c71-00248140a5eb"/>
     <visit visit_id="101" patient_id="100" visit_type_id="1" date_started="2022-02-07 02:10:00.0" creator="1" date_created="2022-02-07 02:10:00.0" voided="0" uuid="j848b0c0-1ade-11e1-9c71-00248140a6eb" />
+    <visit visit_id="102" patient_id="100" visit_type_id="1" date_started="2022-03-07 15:10:00.0" creator="1" date_created="2022-03-07 15:10:00.0" voided="0" uuid="p858b0c0-1ade-11e1-9c71-00248140a6eb" />
 </dataset>

--- a/api/src/test/resources/org/openmrs/module/queue/api/dao/visitQueueEntryDaoTest_initialDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/queue/api/dao/visitQueueEntryDaoTest_initialDataset.xml
@@ -11,6 +11,8 @@
 <dataset>
     <visit_queue_entries visit_queue_entry_id="1" visit_id="101" queue_entry_id="1" creator="1"
                          date_created="2022-02-02 16:38:56.0" voided="false" uuid="5eb8fe43-2813-4kbc-80dc-2e5d30252cc3"/>
+    <visit_queue_entries visit_queue_entry_id="3" visit_id="102" queue_entry_id="3" creator="1"
+                         date_created="2022-02-02 16:38:56.0" voided="false" uuid="6eb7fe43-2813-4kbc-80dc-2e5d30252cc8"/>
 
     <!--Voided Visit Queue entry -->
     <visit_queue_entries visit_queue_entry_id="2" visit_id="101" queue_entry_id="1" creator="1"

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/VisitQueueEntryResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/VisitQueueEntryResource.java
@@ -12,6 +12,7 @@ package org.openmrs.module.queue.web.resources;
 import javax.validation.constraints.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Optional;
 
 import org.openmrs.api.context.Context;
@@ -81,6 +82,15 @@ public class VisitQueueEntryResource extends DelegatingCrudResource<VisitQueueEn
 	@Override
 	protected PageableResult doGetAll(RequestContext requestContext) throws ResponseException {
 		return new NeedsPaging<>(new ArrayList<>(this.visitQueueEntryService.findAllVisitQueueEntries()), requestContext);
+	}
+	
+	@Override
+	protected PageableResult doSearch(RequestContext requestContext) {
+		String status = requestContext.getParameter("status");
+		String service = requestContext.getParameter("service");
+		//Both status & service are nullable
+		Collection<VisitQueueEntry> visitQueueEntries = this.visitQueueEntryService.findVisitQueueEntries(status, service);
+		return new NeedsPaging<>(new ArrayList<>(visitQueueEntries), requestContext);
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/search/handlers/QueueEntrySearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/search/handlers/QueueEntrySearchHandler.java
@@ -42,7 +42,8 @@ public class QueueEntrySearchHandler implements SubResourceSearchHandler {
 		if (StringUtils.isBlank(status) || StringUtils.isBlank(parentUuid)) {
 			return new EmptySearchResult();
 		}
-		Collection<QueueEntry> queueEntries = Context.getService(QueueEntryService.class).searchQueueEntries(status, false);
+		Collection<QueueEntry> queueEntries = Context.getService(QueueEntryService.class)
+		        .searchQueueEntriesByConceptStatus(status, false);
 		return new NeedsPaging<>(new ArrayList<>(queueEntries), requestContext);
 	}
 	


### PR DESCRIPTION
Adds the functionality to filter `visitQueueEntries` by status and service i.e. you'll be able to query for patients waiting for a certain service;
    - `/ws/rest/v1/visit-queue-entry?status=Waiting&service=Triage` - Patients waiting for Triage
    -  `/ws/rest/v1/visit-queue-entry?status=Waiting` - Patients in waiting state
    -  `/ws/rest/v1/visit-queue-entry?service=Clinical consultation` - Patients waiting for clinical consultation or in service...