### PR TITLE
(breaking) O3-2899 - queue service should not limit to only active qu…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>queue</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>queue-api</artifactId>

--- a/api/src/main/java/org/openmrs/module/queue/api/search/QueueEntrySearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/search/QueueEntrySearchCriteria.java
@@ -61,7 +61,7 @@ public class QueueEntrySearchCriteria implements Serializable {
 	
 	private Date startedOnOrBefore;
 	
-	private Boolean isEnded = Boolean.FALSE;
+	private Boolean isEnded = null;
 	
 	private Date endedOnOrAfter;
 	

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>queue</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>queue-integration-tests</artifactId>

--- a/integration-tests/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
@@ -80,7 +80,6 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	public void setup() {
 		QUEUE_INITIAL_DATASET_XML.forEach(this::executeDataSet);
 		criteria = new QueueEntrySearchCriteria();
-		criteria.setIsEnded(null);
 	}
 	
 	@Test

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.openmrs.module</groupId>
         <artifactId>queue</artifactId>
-        <version>2.2.2-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>queue-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>org.openmrs.module</groupId>
     <artifactId>queue</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Queue</name>
     <description>Patient Queues</description>


### PR DESCRIPTION
…eue entries by default

This is a breaking change, as existing queries to the service, including usage by the REST endpoint, will not include both active and ended queue entries by default, unless the "isActive=true" parameter is passed in.  We will need to update the frontend code to ensure this is being passed in, but given this frontend code is a work in progress, and the existing code was causing a lot of confusion and errors, I wanted to get this fixed.