### PR TITLE
O3-2942 - add more modifiable fields when editting/transitioning queue entries

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/model/QueueEntryTransition.java
+++ b/api/src/main/java/org/openmrs/module/queue/model/QueueEntryTransition.java
@@ -34,6 +34,8 @@ public class QueueEntryTransition implements Serializable {
 	
 	private Concept newPriority;
 	
+	private String newPriorityComment;
+	
 	/**
 	 * @return a new queue entry representing what one intends to transition into
 	 */
@@ -43,7 +45,8 @@ public class QueueEntryTransition implements Serializable {
 		queueEntry.setPatient(queueEntryToTransition.getPatient());
 		queueEntry.setVisit(queueEntryToTransition.getVisit());
 		queueEntry.setPriority(newPriority == null ? queueEntryToTransition.getPriority() : newPriority);
-		queueEntry.setPriorityComment(queueEntryToTransition.getPriorityComment());
+		queueEntry.setPriorityComment(
+		    newPriorityComment == null ? queueEntryToTransition.getPriorityComment() : newPriorityComment);
 		queueEntry.setStatus(newStatus == null ? queueEntryToTransition.getStatus() : newStatus);
 		queueEntry.setSortWeight(queueEntryToTransition.getSortWeight());
 		queueEntry.setLocationWaitingFor(queueEntryToTransition.getLocationWaitingFor());

--- a/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
@@ -216,6 +216,7 @@ public class QueueEntryServiceTest {
 		Concept concept1 = new Concept();
 		Concept concept2 = new Concept();
 		String string1 = "starting";
+		String string2 = "some string";
 		double double1 = 5.0;
 		Location location1 = new Location();
 		Provider provider1 = new Provider();
@@ -265,6 +266,7 @@ public class QueueEntryServiceTest {
 		transition2.setTransitionDate(date3);
 		transition2.setNewQueue(queue2);
 		transition2.setNewPriority(concept2);
+		transition2.setNewPriorityComment(string2);
 		transition2.setNewStatus(concept2);
 		QueueEntry queueEntry3 = queueEntryService.transitionQueueEntry(transition2);
 		assertThat(queueEntry2.getEndedAt(), equalTo(date3));
@@ -272,7 +274,7 @@ public class QueueEntryServiceTest {
 		assertThat(queueEntry3.getPatient(), equalTo(patient1));
 		assertThat(queueEntry3.getVisit(), equalTo(visit1));
 		assertThat(queueEntry3.getPriority(), equalTo(concept2));
-		assertThat(queueEntry3.getPriorityComment(), equalTo(string1));
+		assertThat(queueEntry3.getPriorityComment(), equalTo(string2));
 		assertThat(queueEntry3.getStatus(), equalTo(concept2));
 		assertThat(queueEntry3.getSortWeight(), equalTo(double1));
 		assertThat(queueEntry3.getLocationWaitingFor(), equalTo(location1));

--- a/omod/src/main/java/org/openmrs/module/queue/web/QueueEntryTransitionRestController.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/QueueEntryTransitionRestController.java
@@ -47,6 +47,8 @@ public class QueueEntryTransitionRestController extends BaseRestController {
 	
 	public static final String NEW_PRIORITY = "newPriority";
 	
+	public static final String NEW_PRIORITY_COMMENT = "newPriorityComment";
+	
 	private final QueueServicesWrapper services;
 	
 	@Autowired
@@ -101,6 +103,8 @@ public class QueueEntryTransitionRestController extends BaseRestController {
 			}
 			transition.setNewPriority(concept);
 		}
+		
+		transition.setNewPriorityComment(body.get(NEW_PRIORITY_COMMENT));
 		
 		// Execute transition
 		QueueEntry newQueueEntry = services.getQueueEntryService().transitionQueueEntry(transition);

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntryResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntryResource.java
@@ -129,9 +129,13 @@ public class QueueEntryResource extends DelegatingCrudResource<QueueEntry> {
 	public DelegatingResourceDescription getUpdatableProperties() throws ResourceDoesNotSupportOperationException {
 		DelegatingResourceDescription description = new DelegatingResourceDescription();
 		description.addProperty("status");
+		description.addProperty("priority");
 		description.addProperty("priorityComment");
 		description.addProperty("sortWeight");
+		description.addProperty("startedAt");
 		description.addProperty("endedAt");
+		description.addProperty("locationWaitingFor");
+		description.addProperty("providerWaitingFor");
 		return description;
 	}
 	


### PR DESCRIPTION
Expand the list of updatable fields for queue entries. This enables the frontend of have a way to modify queue entries in place. Also changed the queue entry transition endpoint to support editing priorities comment.