### PR TITLE
(fix):Filter Queue Entries to return count of those waiting for a ser…

### DIFF
--- a/omod/src/main/java/org/openmrs/module/queue/web/QueueEntryMetricRestController.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/QueueEntryMetricRestController.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.openmrs.module.queue.api.QueueServicesWrapper;
 import org.openmrs.module.queue.api.search.QueueEntrySearchCriteria;
@@ -71,8 +72,12 @@ public class QueueEntryMetricRestController extends BaseRestController {
 			ret.add(COUNT, services.getQueueEntryService().getCountOfQueueEntries(criteria).intValue());
 		} else {
 			List<QueueEntry> queueEntries = services.getQueueEntryService().getQueueEntries(criteria);
+			// Filter queueEntries where ended_at is null. The  count should be for those waiting for a service
+			List<QueueEntry> filteredQueueEntries = queueEntries.stream().filter(entry -> entry.getEndedAt() == null)
+			        .collect(Collectors.toList());
+			
 			if (metrics.isEmpty() || metrics.contains(COUNT)) {
-				ret.add(COUNT, queueEntries.size());
+				ret.add(COUNT, filteredQueueEntries.size());
 			}
 			if (metrics.isEmpty() || metrics.contains(AVERAGE_WAIT_TIME)) {
 				ret.add(AVERAGE_WAIT_TIME, QueueUtils.computeAverageWaitTimeInMinutes(queueEntries));


### PR DESCRIPTION
…vice

Essentially the queue metrics count should only those waiting for a particular service and not those who have finished with a particular service. The counts should also match what is displayed on the table.

![Screenshot from 2024-03-13 17-18-07](https://github.com/openmrs/openmrs-module-queue/assets/4432218/0e3d5a88-1d37-48e3-b84e-c2c79f3d7a84)
