### PR TITLE
(BREAKING) O3-2748 add endpoint for un-doing transition of queue entries; ren…

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
@@ -60,12 +60,15 @@ public interface QueueEntryService {
 	QueueEntry transitionQueueEntry(@NotNull QueueEntryTransition queueEntryTransition);
 	
 	/**
-	 * Undos a transition by voiding the input queue entry and making its previous queue entry 
-	 * (which MUST not be null) active by setting the previous entry's end time to null. 
+	 * Undos a transition to the input queue entry by voiding it and 
+   * making its previous queue entry active by
+	 * setting the previous entry's end time to null.
 	 * 
-	 * @param queueEntry the queue entry to undo transition from
+	 * @see QueueEntryService#getPreviousQueueEntry(QueueEntry)
+	 * @param queueEntry the queue entry to undo transition to. Must be active
 	 * @return the previous queue entry, re-activated
-	 * 
+	 * @throws IllegalArgumentException if the previous queue entry does not exist
+	 * @throws IllegalStateException if multiple previous entries are identified
 	 */
 	QueueEntry undoTransition(@NotNull QueueEntry queueEntry);
 	
@@ -125,11 +128,12 @@ public interface QueueEntryService {
 	void setSortWeightGenerator(SortWeightGenerator sortWeightGenerator);
 	
 	/**
-	 * Given a specified queue entry, return its previous queue entry (i.e. the queue entry the patient
-	 * transition from to get to the specified one)
+	 * Given a specified queue entry Q, return its previous queue entry P, where P has same patient and
+	 * visit as Q, and P.endedAt time is same as Q.startAt time.
 	 * 
 	 * @param queueEntry
-	 * @return the previous queue entry, if uniquely identifable; null otherwise.
+	 * @return the previous queue entry, null otherwise.
+	 * @throws IllegalStateException if multiple previous queue entries are identified
 	 */
 	QueueEntry getPreviousQueueEntry(@NotNull QueueEntry queueEntry);
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
@@ -60,9 +60,8 @@ public interface QueueEntryService {
 	QueueEntry transitionQueueEntry(@NotNull QueueEntryTransition queueEntryTransition);
 	
 	/**
-	 * Undos a transition to the input queue entry by voiding it and 
-   * making its previous queue entry active by
-	 * setting the previous entry's end time to null.
+	 * Undos a transition to the input queue entry by voiding it and making its previous queue entry
+	 * active by setting the previous entry's end time to null.
 	 * 
 	 * @see QueueEntryService#getPreviousQueueEntry(QueueEntry)
 	 * @param queueEntry the queue entry to undo transition to. Must be active
@@ -129,7 +128,8 @@ public interface QueueEntryService {
 	
 	/**
 	 * Given a specified queue entry Q, return its previous queue entry P, where P has same patient and
-	 * visit as Q, and P.endedAt time is same as Q.startAt time.
+	 * visit as Q, and P.endedAt time is same as Q.startedAt time, and P.queue is same as
+	 * Q.queueComingFrom
 	 * 
 	 * @param queueEntry
 	 * @return the previous queue entry, null otherwise.

--- a/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/QueueEntryService.java
@@ -60,6 +60,16 @@ public interface QueueEntryService {
 	QueueEntry transitionQueueEntry(@NotNull QueueEntryTransition queueEntryTransition);
 	
 	/**
+	 * Undos a transition by voiding the input queue entry and making its previous queue entry 
+	 * (which MUST not be null) active by setting the previous entry's end time to null. 
+	 * 
+	 * @param queueEntry the queue entry to undo transition from
+	 * @return the previous queue entry, re-activated
+	 * 
+	 */
+	QueueEntry undoTransition(@NotNull QueueEntry queueEntry);
+	
+	/**
 	 * Voids a queue entry
 	 *
 	 * @param queueEntry the queue entry to be voided
@@ -113,4 +123,13 @@ public interface QueueEntryService {
 	 * @param sortWeightGenerator the SortWeightGenerator to set
 	 */
 	void setSortWeightGenerator(SortWeightGenerator sortWeightGenerator);
+	
+	/**
+	 * Given a specified queue entry, return its previous queue entry (i.e. the queue entry the patient
+	 * transition from to get to the specified one)
+	 * 
+	 * @param queueEntry
+	 * @return the previous queue entry, if uniquely identifable; null otherwise.
+	 */
+	QueueEntry getPreviousQueueEntry(@NotNull QueueEntry queueEntry);
 }

--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
@@ -64,8 +64,10 @@ public class QueueEntryDaoImpl extends AbstractBaseQueueDaoImpl<QueueEntry> impl
 		limitByCollectionProperty(c, "qe.queueComingFrom", searchCriteria.getQueuesComingFrom());
 		limitToGreaterThanOrEqualToProperty(c, "qe.startedAt", searchCriteria.getStartedOnOrAfter());
 		limitToLessThanOrEqualToProperty(c, "qe.startedAt", searchCriteria.getStartedOnOrBefore());
+		limitToEqualsProperty(c, "qe.startedAt", searchCriteria.getStartedOn());
 		limitToGreaterThanOrEqualToProperty(c, "qe.endedAt", searchCriteria.getEndedOnOrAfter());
 		limitToLessThanOrEqualToProperty(c, "qe.endedAt", searchCriteria.getEndedOnOrBefore());
+		limitToEqualsProperty(c, "qe.endedAt", searchCriteria.getEndedOn());
 		if (searchCriteria.getHasVisit() == Boolean.TRUE) {
 			c.add(Restrictions.isNotNull("qe.visit"));
 		} else if (searchCriteria.getHasVisit() == Boolean.FALSE) {

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
@@ -17,6 +17,7 @@ import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -136,6 +137,8 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	 */
 	@Override
 	public QueueEntry undoTransition(@NotNull QueueEntry queueEntry) {
+		// TODO: Exceptions should be translatable and human readable on the frontend.
+		// See: https://openmrs.atlassian.net/browse/O3-2988
 		if (queueEntry.getVoided()) {
 			throw new IllegalArgumentException("cannot undo transition on a voided queue entry");
 		}
@@ -257,10 +260,11 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 		criteria.setPatient(queueEntry.getPatient());
 		criteria.setVisit(queueEntry.getVisit());
 		criteria.setEndedOn(queueEntry.getStartedAt());
+		criteria.setQueues(Arrays.asList(queueEntry.getQueueComingFrom()));
 		List<QueueEntry> prevQueueEntries = dao.getQueueEntries(criteria);
 		if (prevQueueEntries.size() == 1) {
 			return prevQueueEntries.get(0);
-		} else if(prevQueueEntries.size() > 1) {
+		} else if (prevQueueEntries.size() > 1) {
 			throw new IllegalStateException("Multiple previous queue entries found");
 		} else {
 			return null;

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
@@ -135,7 +135,6 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	 * @see QueueEntryService#undoTransition(QueueEntry)
 	 */
 	@Override
-	@Transactional
 	public QueueEntry undoTransition(@NotNull QueueEntry queueEntry) {
 		if (queueEntry.getVoided()) {
 			throw new IllegalArgumentException("cannot undo transition on a voided queue entry");
@@ -149,7 +148,7 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 		}
 		prevQueueEntry.setEndedAt(null);
 		prevQueueEntry = dao.createOrUpdate(prevQueueEntry);
-			
+		
 		queueEntry.setVoided(true);
 		queueEntry.setVoidReason("undo transition");
 		dao.createOrUpdate(queueEntry);
@@ -252,6 +251,7 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	}
 	
 	@Override
+	@Transactional(readOnly = true)
 	public QueueEntry getPreviousQueueEntry(@NotNull QueueEntry queueEntry) {
 		QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();
 		criteria.setPatient(queueEntry.getPatient());
@@ -260,6 +260,8 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 		List<QueueEntry> prevQueueEntries = dao.getQueueEntries(criteria);
 		if (prevQueueEntries.size() == 1) {
 			return prevQueueEntries.get(0);
+		} else if(prevQueueEntries.size() > 1) {
+			throw new IllegalStateException("Multiple previous queue entries found");
 		} else {
 			return null;
 		}

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
@@ -257,11 +257,14 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	@Transactional(readOnly = true)
 	public QueueEntry getPreviousQueueEntry(@NotNull QueueEntry queueEntry) {
 		Queue queueComingFrom = queueEntry.getQueueComingFrom();
+		if(queueComingFrom == null) {
+			return null;
+		}
 		QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();
 		criteria.setPatient(queueEntry.getPatient());
 		criteria.setVisit(queueEntry.getVisit());
 		criteria.setEndedOn(queueEntry.getStartedAt());
-		criteria.setQueues(queueComingFrom == null ? Arrays.asList() : Arrays.asList(queueComingFrom));
+		criteria.setQueues(Arrays.asList(queueComingFrom));
 		List<QueueEntry> prevQueueEntries = dao.getQueueEntries(criteria);
 		if (prevQueueEntries.size() == 1) {
 			return prevQueueEntries.get(0);

--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
@@ -256,15 +256,18 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	@Override
 	@Transactional(readOnly = true)
 	public QueueEntry getPreviousQueueEntry(@NotNull QueueEntry queueEntry) {
+		Queue queueComingFrom = queueEntry.getQueueComingFrom();
 		QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();
 		criteria.setPatient(queueEntry.getPatient());
 		criteria.setVisit(queueEntry.getVisit());
 		criteria.setEndedOn(queueEntry.getStartedAt());
-		criteria.setQueues(Arrays.asList(queueEntry.getQueueComingFrom()));
+		criteria.setQueues(queueComingFrom == null ? Arrays.asList() : Arrays.asList(queueComingFrom));
 		List<QueueEntry> prevQueueEntries = dao.getQueueEntries(criteria);
 		if (prevQueueEntries.size() == 1) {
 			return prevQueueEntries.get(0);
 		} else if (prevQueueEntries.size() > 1) {
+			// TODO: Exceptions should be translatable and human readable on the frontend.
+			// See: https://openmrs.atlassian.net/browse/O3-2988
 			throw new IllegalStateException("Multiple previous queue entries found");
 		} else {
 			return null;

--- a/api/src/main/java/org/openmrs/module/queue/api/search/QueueEntrySearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/search/QueueEntrySearchCriteria.java
@@ -61,11 +61,15 @@ public class QueueEntrySearchCriteria implements Serializable {
 	
 	private Date startedOnOrBefore;
 	
+	private Date startedOn;
+	
 	private Boolean isEnded = null;
 	
 	private Date endedOnOrAfter;
 	
 	private Date endedOnOrBefore;
+	
+	private Date endedOn;
 	
 	private boolean includedVoided = false;
 }

--- a/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
@@ -284,6 +285,56 @@ public class QueueEntryServiceTest {
 		assertThat(queueEntry3.getQueueComingFrom(), equalTo(queue1));
 		assertThat(queueEntry3.getStartedAt(), equalTo(date3));
 		assertNull(queueEntry3.getEndedAt());
+	}
+
+	@Test
+	public void shouldUndoTransitionQueueEntry() {
+		Patient patient1 = new Patient();
+		Visit visit1 = new Visit();
+		visit1.setPatient(patient1);
+		Queue queue0 = new Queue();
+		Queue queue1 = new Queue();
+		Concept concept1 = new Concept();
+		String string1 = "starting";
+		double double1 = 5.0;
+		Location location1 = new Location();
+		Provider provider1 = new Provider();
+		Date date1 = DateUtils.addHours(new Date(), -12);
+		Date date2 = DateUtils.addHours(date1, 6);
+		
+		QueueEntry queueEntry1 = new QueueEntry();
+		queueEntry1.setQueue(queue1);
+		queueEntry1.setPatient(patient1);
+		queueEntry1.setVisit(visit1);
+		queueEntry1.setPriority(concept1);
+		queueEntry1.setPriorityComment(string1);
+		queueEntry1.setStatus(concept1);
+		queueEntry1.setSortWeight(double1);
+		queueEntry1.setLocationWaitingFor(location1);
+		queueEntry1.setProviderWaitingFor(provider1);
+		queueEntry1.setQueueComingFrom(queue0);
+		queueEntry1.setStartedAt(date1);
+		assertNull(queueEntry1.getEndedAt());
+		
+		// Mock the DAO to return the object being saved
+		when(dao.createOrUpdate(any())).thenAnswer(invocation -> invocation.getArguments()[0]);
+		
+		// Mock the DAO to searches for previous queue entry correctly 
+		QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();
+		criteria.setPatient(patient1);
+		criteria.setVisit(visit1);
+		criteria.setEndedOn(date2);
+		when(dao.getQueueEntries(criteria)).thenReturn(Arrays.asList(queueEntry1));
+
+		// First transition test that no changes are required and all values will be pulled from existing queue entry
+		QueueEntryTransition transition1 = new QueueEntryTransition();
+		transition1.setQueueEntryToTransition(queueEntry1);
+		transition1.setTransitionDate(date2);
+		QueueEntry queueEntry2 = queueEntryService.transitionQueueEntry(transition1);
+
+		queueEntryService.undoTransition(queueEntry2);
+		assertThat(queueEntry2.getVoided(), equalTo(true));
+		assertNull(queueEntry1.getEndedAt());
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
@@ -319,19 +319,20 @@ public class QueueEntryServiceTest {
 		// Mock the DAO to return the object being saved
 		when(dao.createOrUpdate(any())).thenAnswer(invocation -> invocation.getArguments()[0]);
 		
-		// Mock the DAO to searches for previous queue entry correctly 
-		QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();
-		criteria.setPatient(patient1);
-		criteria.setVisit(visit1);
-		criteria.setEndedOn(date2);
-		when(dao.getQueueEntries(criteria)).thenReturn(Arrays.asList(queueEntry1));
-		
-		// First transition test that no changes are required and all values will be pulled from existing queue entry
+		// Create transition
 		QueueEntryTransition transition1 = new QueueEntryTransition();
 		transition1.setQueueEntryToTransition(queueEntry1);
 		transition1.setTransitionDate(date2);
 		QueueEntry queueEntry2 = queueEntryService.transitionQueueEntry(transition1);
 		
+		// Mock the DAO to searches for previous queue entry correctly 
+		QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();
+		criteria.setPatient(patient1);
+		criteria.setVisit(visit1);
+		criteria.setEndedOn(date2);
+		criteria.setQueues(Arrays.asList(queueEntry2.getQueueComingFrom()));
+		when(dao.getQueueEntries(criteria)).thenReturn(Arrays.asList(queueEntry1));
+
 		queueEntryService.undoTransition(queueEntry2);
 		assertThat(queueEntry2.getVoided(), equalTo(true));
 		assertNull(queueEntry1.getEndedAt());

--- a/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
@@ -286,7 +286,7 @@ public class QueueEntryServiceTest {
 		assertThat(queueEntry3.getStartedAt(), equalTo(date3));
 		assertNull(queueEntry3.getEndedAt());
 	}
-
+	
 	@Test
 	public void shouldUndoTransitionQueueEntry() {
 		Patient patient1 = new Patient();
@@ -325,13 +325,13 @@ public class QueueEntryServiceTest {
 		criteria.setVisit(visit1);
 		criteria.setEndedOn(date2);
 		when(dao.getQueueEntries(criteria)).thenReturn(Arrays.asList(queueEntry1));
-
+		
 		// First transition test that no changes are required and all values will be pulled from existing queue entry
 		QueueEntryTransition transition1 = new QueueEntryTransition();
 		transition1.setQueueEntryToTransition(queueEntry1);
 		transition1.setTransitionDate(date2);
 		QueueEntry queueEntry2 = queueEntryService.transitionQueueEntry(transition1);
-
+		
 		queueEntryService.undoTransition(queueEntry2);
 		assertThat(queueEntry2.getVoided(), equalTo(true));
 		assertNull(queueEntry1.getEndedAt());

--- a/omod/src/main/java/org/openmrs/module/queue/web/QueueEntryTransitionRestController.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/QueueEntryTransitionRestController.java
@@ -10,15 +10,17 @@
 package org.openmrs.module.queue.web;
 
 import java.util.Date;
-import java.util.Map;
 import java.util.Optional;
 
 import org.openmrs.Concept;
 import org.openmrs.api.APIException;
+import org.openmrs.module.queue.api.QueueEntryService;
 import org.openmrs.module.queue.api.QueueServicesWrapper;
 import org.openmrs.module.queue.model.Queue;
 import org.openmrs.module.queue.model.QueueEntry;
 import org.openmrs.module.queue.model.QueueEntryTransition;
+import org.openmrs.module.queue.web.dto.QueueEntryTransitionRequest;
+import org.openmrs.module.queue.web.dto.UndoQueueEntryTransitionRequest;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
@@ -34,20 +36,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  * The main controller that exposes additional end points for order entry
  */
 @Controller
-@RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/queue-entry-transition")
 public class QueueEntryTransitionRestController extends BaseRestController {
-	
-	public static final String QUEUE_ENTRY_TO_TRANSITION = "queueEntryToTransition";
-	
-	public static final String TRANSITION_DATE = "transitionDate";
-	
-	public static final String NEW_QUEUE = "newQueue";
-	
-	public static final String NEW_STATUS = "newStatus";
-	
-	public static final String NEW_PRIORITY = "newPriority";
-	
-	public static final String NEW_PRIORITY_COMMENT = "newPriorityComment";
 	
 	private final QueueServicesWrapper services;
 	
@@ -56,58 +45,73 @@ public class QueueEntryTransitionRestController extends BaseRestController {
 		this.services = services;
 	}
 	
-	@RequestMapping(method = { RequestMethod.PUT, RequestMethod.POST })
+	@RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/queue-entry/transition", method = { RequestMethod.PUT,
+	        RequestMethod.POST })
 	@ResponseBody
-	public Object transitionQueueEntry(@RequestBody Map<String, String> body) {
+	public Object transitionQueueEntry(@RequestBody QueueEntryTransitionRequest body) {
 		QueueEntryTransition transition = new QueueEntryTransition();
 		
 		// Queue Entry to Transition
-		String queueEntryUuid = body.get(QUEUE_ENTRY_TO_TRANSITION);
+		String queueEntryUuid = body.getQueueEntryToTransition();
 		QueueEntry queueEntry = services.getQueueEntryService().getQueueEntryByUuid(queueEntryUuid)
-		        .orElseThrow(() -> new APIException(QUEUE_ENTRY_TO_TRANSITION + " is a required parameter"));
+		        .orElseThrow(() -> new APIException("queueEntryToTransition not specified or found"));
 		transition.setQueueEntryToTransition(queueEntry);
 		
 		// Transition Date
 		Date transitionDate = new Date();
-		if (body.containsKey(TRANSITION_DATE)) {
-			transitionDate = (Date) ConversionUtil.convert(body.get(TRANSITION_DATE), Date.class);
+		if (body.getTransitionDate() != null) {
+			transitionDate = (Date) ConversionUtil.convert(body.getTransitionDate(), Date.class);
 		}
 		if (transitionDate == null) {
-			throw new APIException("Invalid transition date specified: " + body.get(TRANSITION_DATE));
+			throw new APIException("Invalid transition date specified: " + body.getTransitionDate());
 		}
 		transition.setTransitionDate(transitionDate);
 		
 		// Queue
-		if (body.containsKey(NEW_QUEUE)) {
-			Optional<Queue> queueOptional = services.getQueueService().getQueueByUuid(body.get(NEW_QUEUE));
+		if (body.getNewQueue() != null) {
+			Optional<Queue> queueOptional = services.getQueueService().getQueueByUuid(body.getNewQueue());
 			if (!queueOptional.isPresent()) {
-				throw new APIException("Invalid queue specified: " + body.get(NEW_QUEUE));
+				throw new APIException("Invalid queue specified: " + body.getNewQueue());
 			}
 			transition.setNewQueue(queueOptional.get());
 		}
 		
 		// Status
-		if (body.containsKey(NEW_STATUS)) {
-			Concept concept = services.getConcept(body.get(NEW_STATUS));
+		if (body.getNewStatus() != null) {
+			Concept concept = services.getConcept(body.getNewStatus());
 			if (concept == null) {
-				throw new APIException("Invalid status specified: " + body.get(NEW_STATUS));
+				throw new APIException("Invalid status specified: " + body.getNewStatus());
 			}
 			transition.setNewStatus(concept);
 		}
 		
 		// Priority
-		if (body.containsKey(NEW_PRIORITY)) {
-			Concept concept = services.getConcept(body.get(NEW_PRIORITY));
+		if (body.getNewPriority() != null) {
+			Concept concept = services.getConcept(body.getNewPriority());
 			if (concept == null) {
-				throw new APIException("Invalid priority specified: " + body.get(NEW_PRIORITY));
+				throw new APIException("Invalid priority specified: " + body.getNewPriority());
 			}
 			transition.setNewPriority(concept);
 		}
 		
-		transition.setNewPriorityComment(body.get(NEW_PRIORITY_COMMENT));
+		transition.setNewPriorityComment(body.getNewPriorityComment());
 		
 		// Execute transition
 		QueueEntry newQueueEntry = services.getQueueEntryService().transitionQueueEntry(transition);
 		return ConversionUtil.convertToRepresentation(newQueueEntry, Representation.REF);
+	}
+	
+	@RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/queue-entry/undo-transition", method = {
+	        RequestMethod.PUT, RequestMethod.POST })
+	@ResponseBody
+	public Object undoTransition(@RequestBody UndoQueueEntryTransitionRequest body) {
+		QueueEntryService qes = services.getQueueEntryService();
+		Optional<QueueEntry> queueEntry = qes.getQueueEntryByUuid(body.getQueueEntry());
+		if (queueEntry.isPresent()) {
+			QueueEntry unEndedQueueEntry = services.getQueueEntryService().undoTransition(queueEntry.get());
+			return ConversionUtil.convertToRepresentation(unEndedQueueEntry, Representation.REF);
+		} else {
+			throw new APIException("Invalid queue entry uuid: " + body);
+		}
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/queue/web/QueueEntryTransitionRestController.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/QueueEntryTransitionRestController.java
@@ -101,8 +101,7 @@ public class QueueEntryTransitionRestController extends BaseRestController {
 		return ConversionUtil.convertToRepresentation(newQueueEntry, Representation.REF);
 	}
 	
-	@RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/queue-entry/undo-transition", method = {
-	        RequestMethod.PUT, RequestMethod.POST })
+	@RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/queue-entry/transition", method = RequestMethod.DELETE)
 	@ResponseBody
 	public Object undoTransition(@RequestBody UndoQueueEntryTransitionRequest body) {
 		QueueEntryService qes = services.getQueueEntryService();
@@ -111,7 +110,7 @@ public class QueueEntryTransitionRestController extends BaseRestController {
 			QueueEntry unEndedQueueEntry = services.getQueueEntryService().undoTransition(queueEntry.get());
 			return ConversionUtil.convertToRepresentation(unEndedQueueEntry, Representation.REF);
 		} else {
-			throw new APIException("Invalid queue entry uuid: " + body);
+			throw new APIException("Invalid queue entry");
 		}
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/queue/web/dto/QueueEntryTransitionRequest.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/dto/QueueEntryTransitionRequest.java
@@ -1,0 +1,28 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.dto;
+
+import lombok.Getter;
+
+@Getter
+public class QueueEntryTransitionRequest {
+	
+	private String queueEntryToTransition;
+	
+	private String transitionDate;
+	
+	private String newQueue;
+	
+	private String newStatus;
+	
+	private String newPriority;
+	
+	private String newPriorityComment;
+}

--- a/omod/src/main/java/org/openmrs/module/queue/web/dto/UndoQueueEntryTransitionRequest.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/dto/UndoQueueEntryTransitionRequest.java
@@ -1,0 +1,18 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UndoQueueEntryTransitionRequest {
+	
+	private String queueEntry;
+}

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntryResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntryResource.java
@@ -177,6 +177,11 @@ public class QueueEntryResource extends DelegatingCrudResource<QueueEntry> {
 			description.addProperty("locationWaitingFor", Representation.DEFAULT);
 			description.addProperty("queueComingFrom", Representation.DEFAULT);
 			description.addProperty("providerWaitingFor", Representation.DEFAULT);
+
+			// gets the previous queue entry, but with REF representation so it doesn't recursively
+			// fetch more previous entries.
+			description.addProperty("previousQueueEntry", Representation.REF);
+
 			description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
 		} else if (representation instanceof FullRepresentation) {
 			addSharedResourceDescriptionProperties(description);
@@ -197,6 +202,7 @@ public class QueueEntryResource extends DelegatingCrudResource<QueueEntry> {
 			description.addProperty("voided");
 			description.addProperty("voidReason");
 			description.addProperty("auditInfo");
+			description.addProperty("previousQueueEntry", Representation.FULL);
 		} else if (representation instanceof CustomRepresentation) {
 			description = null;
 		}
@@ -212,6 +218,11 @@ public class QueueEntryResource extends DelegatingCrudResource<QueueEntry> {
 	public String getDisplay(QueueEntry queueEntry) {
 		PersonName personName = queueEntry.getPatient().getPersonName();
 		return (personName == null ? queueEntry.getPatient().toString() : personName.getFullName());
+	}
+	
+	@PropertyGetter("previousQueueEntry")
+	public QueueEntry getPreviousQueueEntry(QueueEntry queueEntry) {
+		return services.getQueueEntryService().getPreviousQueueEntry(queueEntry);
 	}
 	
 	@Override

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntryResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntryResource.java
@@ -177,11 +177,11 @@ public class QueueEntryResource extends DelegatingCrudResource<QueueEntry> {
 			description.addProperty("locationWaitingFor", Representation.DEFAULT);
 			description.addProperty("queueComingFrom", Representation.DEFAULT);
 			description.addProperty("providerWaitingFor", Representation.DEFAULT);
-
+			
 			// gets the previous queue entry, but with REF representation so it doesn't recursively
 			// fetch more previous entries.
 			description.addProperty("previousQueueEntry", Representation.REF);
-
+			
 			description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
 		} else if (representation instanceof FullRepresentation) {
 			addSharedResourceDescriptionProperties(description);

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/parser/QueueEntrySearchCriteriaParser.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/parser/QueueEntrySearchCriteriaParser.java
@@ -56,11 +56,15 @@ public class QueueEntrySearchCriteriaParser {
 	
 	public static final String SEARCH_PARAM_STARTED_ON_OR_BEFORE = "startedOnOrBefore";
 	
+	public static final String SEARCH_PARAM_STARTED_ON = "startedOn";
+	
 	public static final String SEARCH_PARAM_IS_ENDED = "isEnded";
 	
 	public static final String SEARCH_PARAM_ENDED_ON_OR_AFTER = "endedOnOrAfter";
 	
 	public static final String SEARCH_PARAM_ENDED_ON_OR_BEFORE = "endedOnOrBefore";
+	
+	public static final String SEARCH_PARAM_ENDED_ON = "endedOn";
 	
 	public static final String SEARCH_PARAM_INCLUDE_VOIDED = "includedVoided";
 	
@@ -157,6 +161,11 @@ public class QueueEntrySearchCriteriaParser {
 					criteria.setStartedOnOrBefore(QueueUtils.parseDate(date));
 					break;
 				}
+				case SEARCH_PARAM_STARTED_ON: {
+					String date = parameterMap.get(SEARCH_PARAM_STARTED_ON)[0];
+					criteria.setStartedOn(QueueUtils.parseDate(date));
+					break;
+				}
 				case SEARCH_PARAM_ENDED_ON_OR_AFTER: {
 					String date = parameterMap.get(SEARCH_PARAM_ENDED_ON_OR_AFTER)[0];
 					criteria.setEndedOnOrAfter(QueueUtils.parseDate(date));
@@ -165,6 +174,11 @@ public class QueueEntrySearchCriteriaParser {
 				case SEARCH_PARAM_ENDED_ON_OR_BEFORE: {
 					String date = parameterMap.get(SEARCH_PARAM_ENDED_ON_OR_BEFORE)[0];
 					criteria.setEndedOnOrBefore(QueueUtils.parseDate(date));
+					break;
+				}
+				case SEARCH_PARAM_ENDED_ON: {
+					String date = parameterMap.get(SEARCH_PARAM_ENDED_ON)[0];
+					criteria.setEndedOn(QueueUtils.parseDate(date));
 					break;
 				}
 				case SEARCH_PARAM_IS_ENDED: {


### PR DESCRIPTION
…ame endpoints related to transitions

This PR add the ability to undo queue entry transitions. Undoing a transition voids the current active queue entry and un-ends its previous queue entry. 

I changed the route to REST endpoints related to queue entry transitions to be under `/queue-entry/*`, namely `/queue-entry/transition` and `queue-entry/undo-transition`, hence the breaking change.