### PR TITLE
(fix) O3-3066 update queue entries accordingly after merging patients

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/MergePatientsWithQueueEntriesSaveHandler.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/MergePatientsWithQueueEntriesSaveHandler.java
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api;
+
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Patient;
+import org.openmrs.Person;
+import org.openmrs.User;
+import org.openmrs.annotation.Handler;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.handler.SaveHandler;
+import org.openmrs.module.queue.api.search.QueueEntrySearchCriteria;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.openmrs.person.PersonMergeLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@Handler(supports = PersonMergeLog.class)
+public class MergePatientsWithQueueEntriesSaveHandler implements SaveHandler<PersonMergeLog> {
+	
+	private final Log log = LogFactory.getLog(getClass());
+	
+	private final QueueEntryService queueEntryService;
+	
+	@Autowired
+	public MergePatientsWithQueueEntriesSaveHandler(
+	    @Qualifier("queue.QueueEntryService") QueueEntryService queueEntryService) {
+		this.queueEntryService = queueEntryService;
+	}
+	
+	@Override
+	public void handle(PersonMergeLog mergeLog, User creator, Date dateCreated, String other) {
+		Person winner = mergeLog.getWinner();
+		Person loser = mergeLog.getLoser();
+		Patient winnerPatient = Context.getPatientService().getPatient(winner.getPersonId());
+		Patient loserPatient = Context.getPatientService().getPatient(loser.getPersonId());
+		
+		QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();
+		criteria.setPatient(loserPatient);
+		List<QueueEntry> queueEntries = queueEntryService.getQueueEntries(criteria);
+		for (QueueEntry qe : queueEntries) {
+			qe.setPatient(winnerPatient);
+			queueEntryService.saveQueueEntry(qe);
+			log.trace("Changed queue entry " + qe.getUuid() + ", setting patient to " + winner.getUuid());
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/module/queue/api/MergePatientsWithQueueEntriesSaveHandler.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/MergePatientsWithQueueEntriesSaveHandler.java
@@ -18,7 +18,7 @@ import org.openmrs.Patient;
 import org.openmrs.Person;
 import org.openmrs.User;
 import org.openmrs.annotation.Handler;
-import org.openmrs.api.context.Context;
+import org.openmrs.api.PatientService;
 import org.openmrs.api.handler.SaveHandler;
 import org.openmrs.module.queue.api.search.QueueEntrySearchCriteria;
 import org.openmrs.module.queue.model.QueueEntry;
@@ -33,18 +33,22 @@ public class MergePatientsWithQueueEntriesSaveHandler implements SaveHandler<Per
 	
 	private final QueueEntryService queueEntryService;
 	
+	private final PatientService patientService;
+	
 	@Autowired
 	public MergePatientsWithQueueEntriesSaveHandler(
-	    @Qualifier("queue.QueueEntryService") QueueEntryService queueEntryService) {
+	    @Qualifier("queue.QueueEntryService") QueueEntryService queueEntryService,
+	    @Qualifier("patientService") PatientService patientService) {
 		this.queueEntryService = queueEntryService;
+		this.patientService = patientService;
 	}
 	
 	@Override
 	public void handle(PersonMergeLog mergeLog, User creator, Date dateCreated, String other) {
 		Person winner = mergeLog.getWinner();
 		Person loser = mergeLog.getLoser();
-		Patient winnerPatient = Context.getPatientService().getPatient(winner.getPersonId());
-		Patient loserPatient = Context.getPatientService().getPatient(loser.getPersonId());
+		Patient winnerPatient = patientService.getPatient(winner.getPersonId());
+		Patient loserPatient = patientService.getPatient(loser.getPersonId());
 		
 		QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();
 		criteria.setPatient(loserPatient);

--- a/integration-tests/src/test/java/org/openmrs/module/queue/api/MergePatientsWithQueueEntriesSaveHandlerTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/queue/api/MergePatientsWithQueueEntriesSaveHandlerTest.java
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.api;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Patient;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.SpringTestConfiguration;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(classes = SpringTestConfiguration.class, inheritLocations = false)
+public class MergePatientsWithQueueEntriesSaveHandlerTest extends BaseModuleContextSensitiveTest {
+	
+	private static final List<String> INITIAL_DATASET_XML = Arrays.asList(
+	    "org/openmrs/module/queue/api/dao/QueueDaoTest_locationInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_conceptsInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_patientInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/VisitQueueEntryDaoTest_visitInitialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueDaoTest_initialDataset.xml",
+	    "org/openmrs/module/queue/api/dao/QueueEntryDaoTest_initialDataset.xml",
+	    "org/openmrs/module/queue/validators/QueueEntryValidatorTest_globalPropertyInitialDataset.xml");
+	
+	@Autowired
+	@Qualifier("queue.QueueEntryService")
+	private QueueEntryService queueEntryService;
+	
+	@Before
+	public void setup() {
+		INITIAL_DATASET_XML.forEach(this::executeDataSet);
+	}
+	
+	@Test
+	public void shouldChangeQueueEntryPatientOnMergingPatient() throws Exception {
+		PatientService ps = Context.getPatientService();
+		Patient winnerPatient = ps.getPatient(100);
+		Patient loserPatient = ps.getPatient(101);
+		
+		// set up queue entry for loserPatient
+		QueueEntry queueEntryToCloneFrom = queueEntryService.getQueueEntryById(1).get();
+		QueueEntry queueEntry = new QueueEntry();
+		queueEntry.setPatient(loserPatient);
+		queueEntry.setQueue(queueEntryToCloneFrom.getQueue());
+		queueEntry.setStatus(queueEntryToCloneFrom.getStatus());
+		queueEntry.setPriority(queueEntryToCloneFrom.getPriority());
+		queueEntry.setStartedAt(new Date());
+		queueEntryService.saveQueueEntry(queueEntry);
+		
+		assertThat(queueEntry.getPatient().getPatientId(), is(loserPatient.getPatientId()));
+		ps.mergePatients(winnerPatient, loserPatient);
+		queueEntry = queueEntryService.getQueueEntryById(11).get();
+		assertThat(queueEntry.getPatient().getPatientId(), is(winnerPatient.getPatientId()));
+	}
+}

--- a/integration-tests/src/test/resources/org/openmrs/module/queue/api/dao/QueueEntryDaoTest_patientInitialDataset.xml
+++ b/integration-tests/src/test/resources/org/openmrs/module/queue/api/dao/QueueEntryDaoTest_patientInitialDataset.xml
@@ -11,9 +11,9 @@
 <dataset>
     <patient_identifier_type patient_identifier_type_id="1" name="Test Identifier Type" description="Test description"
                              creator="1" date_created="2022-02-02 12:34:00.0" required="false" retired="false"
-                             uuid="c5576187-9a67-43a7-9b7c-04db22851233"/>
+                             uuid="c5576187-9a67-43a7-9b7c-04db22851233" validator="[NULL]"/>
     <person person_id="100" gender="M" dead="false" creator="1" date_created="2022-02-02 12:34:00.0" voided="false"
-            uuid="90b38324-e2fd-4feb-95b7-9e9a2a8876fg"/>
+            uuid="90b38324-e2fd-4feb-95b7-9e9a2a8876fg" birthdate_estimated="false" />
     <person_name person_name_id="2" preferred="true" person_id="100" given_name="nobody" middle_name="C" family_name="no-name"
                  creator="1" date_created="2022-02-02 12:34:00.0" voided="false"
                  uuid="7e2acadc-5073-4a39-914a-debcbec8c1c9"/>
@@ -21,4 +21,14 @@
     <patient_identifier patient_identifier_id="1" patient_id="100" identifier="1234-5" identifier_type="1" preferred="1"
                         location_id="1" creator="1" date_created="2022-02-02 12:34:00.0" voided="false"
                         uuid="e887ac86-4d8a-40f3-bedb-da84d34517b7"/>
+
+    <person person_id="101" gender="M" dead="false" creator="1" date_created="2022-02-02 12:36:00.0" voided="false"
+            uuid="5c3abc9c-0b59-47c0-bc98-8f5b8f9be007" birthdate_estimated="false" />
+    <person_name person_name_id="2" preferred="true" person_id="101" given_name="nobody" middle_name="C" family_name="no-name"
+                    creator="1" date_created="2022-02-02 12:36:00.0" voided="false"
+                    uuid="57aed902-2268-416f-9068-eb3a1b17b9cf"/>
+    <patient patient_id="101" creator="1" date_created="2022-02-02 12:36:00.0" voided="false"/>
+    <patient_identifier patient_identifier_id="2" patient_id="101" identifier="1234-6" identifier_type="1" preferred="1"
+                        location_id="1" creator="1" date_created="2022-02-02 12:36:00.0" voided="false"
+                        uuid="38e94790-0c7e-4d87-aa7d-e84bc5e1501f  "/>
 </dataset>


### PR DESCRIPTION
When merging 2 patients, all queue entries from the loser (voided) patient should be set to associate with the winner patient.

This PR does it by adding a SaveHandler on PersonMergeLog. Not sure if this is the right approach, since we have the same issue of needing to update queue entries when merging visits, we can't do something similar since there is no VisitMergeLog. 