### PR TITLE
(feat) O3-3184 allow changing of LocationWaitingFor and ProviderWaiti…

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
@@ -257,7 +257,7 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	@Transactional(readOnly = true)
 	public QueueEntry getPreviousQueueEntry(@NotNull QueueEntry queueEntry) {
 		Queue queueComingFrom = queueEntry.getQueueComingFrom();
-		if(queueComingFrom == null) {
+		if (queueComingFrom == null) {
 			return null;
 		}
 		QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();

--- a/api/src/main/java/org/openmrs/module/queue/model/QueueEntryTransition.java
+++ b/api/src/main/java/org/openmrs/module/queue/model/QueueEntryTransition.java
@@ -14,6 +14,8 @@ import java.util.Date;
 
 import lombok.Data;
 import org.openmrs.Concept;
+import org.openmrs.Location;
+import org.openmrs.Provider;
 
 /**
  * Bean definition that encapsulates the supported criteria for saving a direct transition from one
@@ -36,6 +38,10 @@ public class QueueEntryTransition implements Serializable {
 	
 	private String newPriorityComment;
 	
+	private Location newLocationWaitingFor; // value obtrained from queueEntryToTransition if not provided by request
+	
+	private Provider newProviderWaitingFor; // value obtrained from queueEntryToTransition if not provided by request
+	
 	/**
 	 * @return a new queue entry representing what one intends to transition into
 	 */
@@ -49,8 +55,8 @@ public class QueueEntryTransition implements Serializable {
 		    newPriorityComment == null ? queueEntryToTransition.getPriorityComment() : newPriorityComment);
 		queueEntry.setStatus(newStatus == null ? queueEntryToTransition.getStatus() : newStatus);
 		queueEntry.setSortWeight(queueEntryToTransition.getSortWeight());
-		queueEntry.setLocationWaitingFor(queueEntryToTransition.getLocationWaitingFor());
-		queueEntry.setProviderWaitingFor(queueEntryToTransition.getProviderWaitingFor());
+		queueEntry.setLocationWaitingFor(newLocationWaitingFor);
+		queueEntry.setProviderWaitingFor(newProviderWaitingFor);
 		queueEntry.setQueueComingFrom(queueEntryToTransition.getQueue());
 		queueEntry.setStartedAt(transitionDate);
 		return queueEntry;

--- a/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
@@ -248,6 +248,8 @@ public class QueueEntryServiceTest {
 		QueueEntryTransition transition1 = new QueueEntryTransition();
 		transition1.setQueueEntryToTransition(queueEntry1);
 		transition1.setTransitionDate(date2);
+		transition1.setNewLocationWaitingFor(location1);
+		transition1.setNewProviderWaitingFor(provider1);
 		QueueEntry queueEntry2 = queueEntryService.transitionQueueEntry(transition1);
 		assertThat(queueEntry1.getEndedAt(), equalTo(date2));
 		assertThat(queueEntry2.getQueue(), equalTo(queue1));
@@ -280,8 +282,8 @@ public class QueueEntryServiceTest {
 		assertThat(queueEntry3.getPriorityComment(), equalTo(string2));
 		assertThat(queueEntry3.getStatus(), equalTo(concept2));
 		assertThat(queueEntry3.getSortWeight(), equalTo(double1));
-		assertThat(queueEntry3.getLocationWaitingFor(), equalTo(location1));
-		assertThat(queueEntry3.getProviderWaitingFor(), equalTo(provider1));
+		assertThat(queueEntry3.getLocationWaitingFor(), equalTo(null));
+		assertThat(queueEntry3.getProviderWaitingFor(), equalTo(null));
 		assertThat(queueEntry3.getQueueComingFrom(), equalTo(queue1));
 		assertThat(queueEntry3.getStartedAt(), equalTo(date3));
 		assertNull(queueEntry3.getEndedAt());
@@ -332,7 +334,7 @@ public class QueueEntryServiceTest {
 		criteria.setEndedOn(date2);
 		criteria.setQueues(Arrays.asList(queueEntry2.getQueueComingFrom()));
 		when(dao.getQueueEntries(criteria)).thenReturn(Arrays.asList(queueEntry1));
-
+		
 		queueEntryService.undoTransition(queueEntry2);
 		assertThat(queueEntry2.getVoided(), equalTo(true));
 		assertNull(queueEntry1.getEndedAt());

--- a/omod/src/main/java/org/openmrs/module/queue/web/dto/QueueEntryTransitionRequest.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/dto/QueueEntryTransitionRequest.java
@@ -25,4 +25,12 @@ public class QueueEntryTransitionRequest {
 	private String newPriority;
 	
 	private String newPriorityComment;
+	
+	private String newLocationWaitingFor;
+	
+	private String newProviderWaitingFor;
+
+	public static final String NEW_LOCATION_WAITING_FOR_FIELD = "newLocationWaitingFor";
+
+	public static final String NEW_PROVIDER_WAITING_FOR_FIELD = "newProviderWaitingFor";
 }


### PR DESCRIPTION
…ngFor during a transition

This PR add `locationWaitingFor` and `providerWaitingFor` as attributes that are changeable during a transition. 

The logic here is a bit strange since these fields may be set to null, and we need to way to distinguish between "changing the field to null" vs "keeping the field as it was". It does that by determining whether the optional attributes `newLocationWaitingFor` and `newProviderWaitingFor` exists in the `/queue-entry/transition` request body. If not, those fields do not get changed. 