### PR TITLE
O3-5445: Fix duplicate SQL query in AbstractBaseQueueDaoImpl#get(String uuid)

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/AbstractBaseQueueDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/AbstractBaseQueueDaoImpl.java
@@ -60,8 +60,8 @@ public class AbstractBaseQueueDaoImpl<Q extends OpenmrsObject & Auditable> imple
 	public Optional<Q> get(@NotNull String uuid) {
 		Criteria criteria = getCurrentSession().createCriteria(getClazz());
 		includeVoidedObjects(criteria, false);
-		criteria.add(eq("uuid", uuid)).uniqueResult();
-		return Optional.ofNullable((Q) criteria.add(eq("uuid", uuid)).uniqueResult());
+		criteria.add(eq("uuid", uuid));
+		return Optional.ofNullable((Q) criteria.uniqueResult());
 	}
 	
 	@Override


### PR DESCRIPTION
## Description
`AbstractBaseQueueDaoImpl#get(String uuid)` was calling `criteria.add(eq("uuid", uuid)).uniqueResult()` twice on the same mutable `Criteria` object - firing two SQL queries per UUID lookup and adding a redundant duplicate `WHERE uuid = ?` clause on the second query.

This affected every UUID-based entity lookup across the module (`QueueEntry`, `Queue`, `QueueRoom`, `RoomProviderMap`).

Fix removes the orphaned first call and keeps a single `criteria.add(...) → uniqueResult()` chain.

## Related
https://openmrs.atlassian.net/jira/software/c/projects/O3/boards/37?selectedIssue=O3-5445