### PR TITLE
O3-5485 Fix NaN average wait time when all queue entries have null endedAt

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/utils/QueueUtils.java
+++ b/api/src/main/java/org/openmrs/module/queue/utils/QueueUtils.java
@@ -62,16 +62,24 @@ public class QueueUtils {
 		if (queueEntries != null && !queueEntries.isEmpty()) {
 			double totalWaitTime = 0.0;
 			int numEntries = 0;
+			
 			for (QueueEntry e : queueEntries) {
 				LocalDateTime startedAt = convertToLocalDateTimeInSystemDefaultTimezone(e.getStartedAt());
 				LocalDateTime endedAt = convertToLocalDateTimeInSystemDefaultTimezone(e.getEndedAt());
+				
 				if (startedAt != null && endedAt != null) {
 					totalWaitTime += Duration.between(startedAt, endedAt).toMinutes();
 					numEntries++;
 				}
 			}
-			averageWaitTime = totalWaitTime / numEntries;
+			
+			if (numEntries == 0) {
+				averageWaitTime = 0.0;
+			} else {
+				averageWaitTime = totalWaitTime / numEntries;
+			}
 		}
+		
 		return averageWaitTime;
 	}
 	

--- a/api/src/test/java/org/openmrs/module/queue/utils/QueueUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/utils/QueueUtilsTest.java
@@ -12,9 +12,12 @@ package org.openmrs.module.queue.utils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import org.junit.Test;
+import org.openmrs.module.queue.model.QueueEntry;
 
 public class QueueUtilsTest {
 	
@@ -51,5 +54,30 @@ public class QueueUtilsTest {
 		assertThat(QueueUtils.datesOverlap(AUG_2, AUG_4, AUG_1, AUG_3), is(true)); // one starts within two
 		assertThat(QueueUtils.datesOverlap(AUG_3, AUG_4, AUG_1, AUG_2), is(false)); // one after two
 		assertThat(QueueUtils.datesOverlap(AUG_1, AUG_2, AUG_1, AUG_3), is(true)); // one starts when two starts
+	}
+	
+	@Test
+	public void shouldReturnZeroWhenQueueEntriesListIsEmpty() {
+		
+		List<QueueEntry> entries = new ArrayList<>();
+		
+		double result = QueueUtils.computeAverageWaitTimeInMinutes(entries);
+		
+		assertThat(result, is(0.0));
+	}
+	
+	@Test
+	public void shouldReturnZeroWhenAllEntriesHaveNullEndedAt() {
+		
+		QueueEntry entry = new QueueEntry();
+		entry.setStartedAt(new Date());
+		entry.setEndedAt(null);
+		
+		List<QueueEntry> entries = new ArrayList<>();
+		entries.add(entry);
+		
+		double result = QueueUtils.computeAverageWaitTimeInMinutes(entries);
+		
+		assertThat(result, is(0.0));
 	}
 }


### PR DESCRIPTION
## Description
Fixes an issue where computeAverageWaitTimeInMinutes could return NaN when all queue entries had null endedAt values.

## Changes
- Updated the logic to only calculate the average using entries that have both startedAt and endedAt.
- Added a check to return 0 when there are no valid entries to calculate the wait time.
- Added unit tests to cover this case.

## Testing
Ran the test suite using:
mvn clean test

All tests passed successfully.

## Related
https://openmrs.atlassian.net/browse/O3-5485