### PR TITLE
O3-5503: Fix duplicate patient property and missing visit property in QueueEntrySubResource RefRepresentation

### DIFF
--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntrySubResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntrySubResource.java
@@ -154,7 +154,7 @@ public class QueueEntrySubResource extends DelegatingSubResource<QueueEntry, Que
 			this.addSharedResourceDescriptionProperties(resourceDescription);
 			resourceDescription.addProperty("status", Representation.REF);
 			resourceDescription.addProperty("patient", Representation.REF);
-			resourceDescription.addProperty("patient", Representation.REF);
+			resourceDescription.addProperty("visit", Representation.REF);
 			resourceDescription.addProperty("priority", Representation.REF);
 			resourceDescription.addProperty("locationWaitingFor", Representation.REF);
 			resourceDescription.addProperty("queueComingFrom", Representation.REF);


### PR DESCRIPTION
## Description

`QueueEntrySubResource#getRepresentationDescription()` has a copy-paste error in the `RefRepresentation` block: the `patient` property is added twice, while the `visit` property is missing entirely.

This means REST API responses from `/ws/rest/v1/queue/{uuid}/entry` with `v=ref` representation include redundant patient data and omit visit data.

## Changes

One-line fix: replaced the duplicate `patient` property declaration with `visit` on line 157.

```diff
- resourceDescription.addProperty("patient", Representation.REF);
+ resourceDescription.addProperty("visit", Representation.REF);
```
## Evidence

The DefaultRepresentation and FullRepresentation in the same file both correctly include visit. The parent resource (QueueEntryResource.java) also correctly includes both patient and visit in its RefRepresentation.

## Issue
[O3-5503](https://openmrs.atlassian.net/browse/O3-5503)

[O3-5503]: https://openmrs.atlassian.net/browse/O3-5503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ