### PR TITLE
(fix) O3-5569: Fix incorrect error code in QueueValidator

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/validators/QueueValidator.java
+++ b/api/src/main/java/org/openmrs/module/queue/validators/QueueValidator.java
@@ -45,7 +45,7 @@ public class QueueValidator implements Validator {
 		
 		QueueServicesWrapper queueServices = Context.getRegisteredComponents(QueueServicesWrapper.class).get(0);
 		if (queue.getService() == null) {
-			errors.rejectValue("service", "QueueEntry.service.null", "The property service should not be null");
+			errors.rejectValue("service", "Queue.service.null", "The property service should not be null");
 		} else {
 			if (!queueServices.getAllowedServices().contains(queue.getService())) {
 				errors.rejectValue("service", "Queue.service.invalid",


### PR DESCRIPTION
## Description
While looking at QueueValidator and QueueEntryValidator found an error registration with a QueueEntry.service.null instead of Queue.service.null which looks odd. This is inconsistent with the other error codes in the same file (`queue.name.null`, `queue.location.null`, `Queue.service.invalid`).

Changed to `Queue.service.null`

## Related Issue

https://openmrs.atlassian.net/browse/O3-5569