### PR TITLE
O3-5396: Fix NPE when undoing a queue transition

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
@@ -117,7 +117,10 @@ public class QueueEntryDaoImpl extends AbstractBaseQueueDaoImpl<QueueEntry> impl
 		}
 		
 		javax.persistence.Query query = session.createQuery(jpql.toString());
-		query.setParameter("endedAt", Date.from(queueEntry.getEndedAt().toInstant().truncatedTo(ChronoUnit.SECONDS)));
+		Date endedAt = queueEntry.getEndedAt() != null
+		        ? Date.from(queueEntry.getEndedAt().toInstant().truncatedTo(ChronoUnit.SECONDS))
+		        : null;
+		query.setParameter("endedAt", endedAt);
 		query.setParameter("id", queueEntry.getQueueEntryId());
 		if (expectedDateChanged != null) {
 			query.setParameter("expectedDateChanged", expectedDateChanged);

--- a/integration-tests/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
@@ -410,6 +410,22 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	@Test
+	public void updateIfUnmodified_shouldClearEndedAtWhenSetToNull() {
+		// Entry 1 has ended_at set; this mirrors what undoTransition does when re-opening a previous entry
+		QueueEntry queueEntry = dao.get(QUEUE_ENTRY_UUID).orElseThrow(IllegalStateException::new);
+		assertThat(queueEntry.getEndedAt(), notNullValue());
+		
+		queueEntry.setEndedAt(null);
+		
+		// date_changed is null in the dataset, so expectedDateChanged is null
+		boolean updated = dao.updateIfUnmodified(queueEntry, queueEntry.getDateChanged());
+		
+		assertThat(updated, is(true));
+		QueueEntry reloaded = dao.get(QUEUE_ENTRY_UUID).orElseThrow(IllegalStateException::new);
+		assertThat(reloaded.getEndedAt(), nullValue());
+	}
+	
+	@Test
 	// 2022-02-02 18:40:56.0, 2022-02-02 18:41:56.0
 	public void shouldSearchAndCountQueueEntriesEndedOnOrAfterDate() {
 		assertNumberOfResults(criteria, 4);


### PR DESCRIPTION
When we undo a queue transition, we do this:
```
prevQueueEntry.setEndedAt(null);
boolean updated = dao.updateIfUnmodified(prevQueueEntry, expectedDateChanged);
```

This PR adds a null check to the endAt tiime to avoid NPE.