### PR TITLE
(fix) O3-5594:  Fix errors when voiding patient with multiple queue e…

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/QueueEntryDaoImpl.java
@@ -87,6 +87,12 @@ public class QueueEntryDaoImpl extends AbstractBaseQueueDaoImpl<QueueEntry> impl
 			predicates.add(cb.or(root.get("endedAt").isNull(), cb.greaterThan(root.get("endedAt"), startedAt)));
 		}
 		
+		Date endedAt = searchCriteria.getEndedOn();
+		if (endedAt != null) {
+			// any queue entries that started before this queue entry ends
+			predicates.add(cb.lessThan(root.get("startedAt"), endedAt));
+		}
+		
 		query.where(cb.and(predicates.toArray(new Predicate[0])));
 		
 		return session.createQuery(query).list();

--- a/api/src/main/java/org/openmrs/module/queue/validators/QueueEntryValidator.java
+++ b/api/src/main/java/org/openmrs/module/queue/validators/QueueEntryValidator.java
@@ -104,6 +104,9 @@ public class QueueEntryValidator implements Validator {
 	private boolean isDuplicate(QueueEntry queueEntry, QueueEntryService queueEntryService) {
 		List<QueueEntry> queueEntries = queueEntryService.getOverlappingQueueEntries(queueEntry.getPatient(),
 		    queueEntry.getQueue(), queueEntry.getStartedAt(), queueEntry.getEndedAt());
+		// cascade voids (e.g. voiding a patient) may not yet be flushed to the DB when this runs,
+		// so voided entries can slip through the DAO-level filter — remove them here as a safety net
+		queueEntries.removeIf(QueueEntry::getVoided);
 		
 		// if we aren't checking an existing queue entry, any overlaps are "duplicates"
 		if (queueEntry.getId() == null) {

--- a/integration-tests/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
+++ b/integration-tests/src/test/java/org/openmrs/module/queue/api/dao/QueueEntryDaoTest.java
@@ -426,6 +426,35 @@ public class QueueEntryDaoTest extends BaseModuleContextSensitiveTest {
 		assertResults(criteria, 2, 3);
 	}
 	
+	@Test
+	// Dataset entries for queue=3, patient=2: only entry 4 [2022-03-02 16:40:56 → 2022-03-02 18:41:56]
+	public void getOverlappingQueueEntries_shouldReturnEntriesOverlappingWithGivenRange() {
+		Queue queue3 = services.getQueueService().getQueueById(3).orElseThrow(IllegalStateException::new);
+		Patient patient2 = services.getPatientService().getPatient(2);
+		
+		// Open-ended new entry: endedAt=null — entry 4 overlaps (its endedAt > new startedAt)
+		QueueEntrySearchCriteria openCriteria = QueueEntrySearchCriteria.builder().queues(Collections.singletonList(queue3))
+		        .patient(patient2).startedOn(date("2022-03-02 10:00:00")).build();
+		List<QueueEntry> openResults = dao.getOverlappingQueueEntries(openCriteria);
+		assertThat(openResults, hasSize(1));
+		assertThat(openResults.get(0).getQueueEntryId(), is(4));
+		
+		// Finite new entry whose range overlaps entry 4: new [10:00 → 17:00], entry 4 starts at 16:40 < 17:00
+		QueueEntrySearchCriteria overlapCriteria = QueueEntrySearchCriteria.builder()
+		        .queues(Collections.singletonList(queue3)).patient(patient2).startedOn(date("2022-03-02 10:00:00"))
+		        .endedOn(date("2022-03-02 17:00:00")).build();
+		List<QueueEntry> overlapResults = dao.getOverlappingQueueEntries(overlapCriteria);
+		assertThat(overlapResults, hasSize(1));
+		assertThat(overlapResults.get(0).getQueueEntryId(), is(4));
+		
+		// Finite new entry that ends BEFORE entry 4 starts: new [10:00 → 15:00], entry 4 starts at 16:40 — no overlap
+		QueueEntrySearchCriteria noOverlapCriteria = QueueEntrySearchCriteria.builder()
+		        .queues(Collections.singletonList(queue3)).patient(patient2).startedOn(date("2022-03-02 10:00:00"))
+		        .endedOn(date("2022-03-02 15:00:00")).build();
+		List<QueueEntry> noOverlapResults = dao.getOverlappingQueueEntries(noOverlapCriteria);
+		assertThat(noOverlapResults, hasSize(0));
+	}
+	
 	/**
 	 * Utility method that tests criteria against both DAO methods to getQueueEntries and
 	 * getCountOfQueueEntries


### PR DESCRIPTION
…ntries

This PR fixes the following errors when voiding patient with multiple queue entries:
- `dao.getOverlappingQueueEntries()` function does not take into account of endAt time correctly in the overlap check
- the `isDuplicate()` function check fails because it loops through voided queue entries. Even though the `getOverlappingQueueEntries()` call within the function should only return non-voided entries, it doesn’t actually do that for entries being voided during a cascade void (of the patient) because the void value hasn’t been committed to the DB yet.