### PR TITLE
(fix) O3-5607: Prevent NPE when assignTicket payload fields are missing

### DIFF
--- a/omod/src/main/java/org/openmrs/module/queue/web/Legacy1xRestController.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/Legacy1xRestController.java
@@ -208,9 +208,9 @@ public class Legacy1xRestController extends BaseRestController {
 				return new ResponseEntity<Object>(msg, new HttpHeaders(), HttpStatus.OK);
 			}
 			
-			String servicePointName = actualObj.get("servicePointName").textValue();
-			String ticketNumber = actualObj.get("ticketNumber").textValue();
-			String status = actualObj.get("status").textValue();
+			String servicePointName = actualObj.path("servicePointName").asText("");
+			String ticketNumber = actualObj.path("ticketNumber").asText("");
+			String status = actualObj.path("status").asText("");
 			
 			if (servicePointName.isEmpty() || ticketNumber.isEmpty() || status.isEmpty()) {
 				return new ResponseEntity<Object>("One of the required fields is empty", new HttpHeaders(), BAD_REQUEST);

--- a/omod/src/main/java/org/openmrs/module/queue/web/Legacy1xRestController.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/Legacy1xRestController.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
@@ -199,27 +200,44 @@ public class Legacy1xRestController extends BaseRestController {
 	@ResponseBody
 	public Object assignTicketToServicePoint(HttpServletRequest request) throws Exception {
 		String requestBody = IOUtils.toString(request.getReader());
-		if (requestBody != null) {
-			ObjectMapper mapper = new ObjectMapper();
-			JsonNode actualObj = mapper.readTree(requestBody);
-			
-			if (!actualObj.has("ticketNumber")) {
-				String msg = "No ticketNumber passed, skipping ticket assignment";
-				return new ResponseEntity<Object>(msg, new HttpHeaders(), HttpStatus.OK);
-			}
-			
-			String servicePointName = actualObj.path("servicePointName").asText("");
-			String ticketNumber = actualObj.path("ticketNumber").asText("");
-			String status = actualObj.path("status").asText("");
-			
-			if (servicePointName.isEmpty() || ticketNumber.isEmpty() || status.isEmpty()) {
-				return new ResponseEntity<Object>("One of the required fields is empty", new HttpHeaders(), BAD_REQUEST);
-			}
-			
-			QueueTicketAssignments.updateTicketAssignment(servicePointName, ticketNumber, status);
-			return new ResponseEntity<Object>("Ticket successfully assigned!", new HttpHeaders(), HttpStatus.OK);
+		if (requestBody == null || requestBody.isBlank()) {
+			return new ResponseEntity<Object>("The request could not be interpreted", new HttpHeaders(), BAD_REQUEST);
 		}
-		return new ResponseEntity<Object>("The request could not be interpreted", new HttpHeaders(), BAD_REQUEST);
+		ObjectMapper mapper = new ObjectMapper();
+		JsonNode actualObj;
+		try {
+			actualObj = mapper.readTree(requestBody);
+		}
+		catch (JsonProcessingException e) {
+			return new ResponseEntity<Object>("The request could not be interpreted", new HttpHeaders(), BAD_REQUEST);
+		}
+		
+		if (!actualObj.has("ticketNumber")) {
+			String msg = "No ticketNumber passed, skipping ticket assignment";
+			return new ResponseEntity<Object>(msg, new HttpHeaders(), HttpStatus.OK);
+		}
+		
+		JsonNode servicePointNameNode = actualObj.path("servicePointName");
+		JsonNode ticketNumberNode = actualObj.path("ticketNumber");
+		JsonNode statusNode = actualObj.path("status");
+		
+		if (servicePointNameNode.isMissingNode() || servicePointNameNode.isNull() || !servicePointNameNode.isTextual()
+		        || ticketNumberNode.isMissingNode() || ticketNumberNode.isNull() || !ticketNumberNode.isTextual()
+		        || statusNode.isMissingNode() || statusNode.isNull() || !statusNode.isTextual()) {
+			return new ResponseEntity<Object>("One of the required fields is missing or is not a string", new HttpHeaders(),
+			        BAD_REQUEST);
+		}
+		
+		String servicePointName = servicePointNameNode.textValue();
+		String ticketNumber = ticketNumberNode.textValue();
+		String status = statusNode.textValue();
+		
+		if (servicePointName.isEmpty() || ticketNumber.isEmpty() || status.isEmpty()) {
+			return new ResponseEntity<Object>("One of the required fields is empty", new HttpHeaders(), BAD_REQUEST);
+		}
+		
+		QueueTicketAssignments.updateTicketAssignment(servicePointName, ticketNumber, status);
+		return new ResponseEntity<Object>("Ticket successfully assigned!", new HttpHeaders(), HttpStatus.OK);
 	}
 	
 	@RequestMapping(method = GET, value = "/rest/" + RestConstants.VERSION_1 + "/queueutil/active-tickets")

--- a/omod/src/test/java/org/openmrs/module/queue/web/Legacy1xRestControllerAssignTicketTest.java
+++ b/omod/src/test/java/org/openmrs/module/queue/web/Legacy1xRestControllerAssignTicketTest.java
@@ -1,0 +1,112 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.queue.web;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.OK;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmrs.module.queue.api.QueueServicesWrapper;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+public class Legacy1xRestControllerAssignTicketTest {
+	
+	private Legacy1xRestController controller;
+	
+	@Mock
+	private QueueServicesWrapper services;
+	
+	@BeforeEach
+	public void setUp() {
+		controller = new Legacy1xRestController(services);
+	}
+	
+	private HttpServletRequest mockRequestWithBody(String body) throws Exception {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		when(request.getReader()).thenReturn(new BufferedReader(new StringReader(body)));
+		return request;
+	}
+	
+	@Test
+	public void assignTicket_shouldReturn400WhenBodyIsEmpty() throws Exception {
+		HttpServletRequest request = mockRequestWithBody("");
+		ResponseEntity<?> response = (ResponseEntity<?>) controller.assignTicketToServicePoint(request);
+		assertThat(response.getStatusCode(), equalTo(BAD_REQUEST));
+	}
+	
+	@Test
+	public void assignTicket_shouldReturn400WhenBodyIsInvalidJson() throws Exception {
+		HttpServletRequest request = mockRequestWithBody("not-json{{{");
+		ResponseEntity<?> response = (ResponseEntity<?>) controller.assignTicketToServicePoint(request);
+		assertThat(response.getStatusCode(), equalTo(BAD_REQUEST));
+	}
+	
+	@Test
+	public void assignTicket_shouldReturnOkWhenTicketNumberIsMissing() throws Exception {
+		// When ticketNumber is absent, the endpoint intentionally skips assignment and returns 200
+		HttpServletRequest request = mockRequestWithBody("{\"servicePointName\":\"Room1\",\"status\":\"pending\"}");
+		ResponseEntity<?> response = (ResponseEntity<?>) controller.assignTicketToServicePoint(request);
+		assertThat(response.getStatusCode(), equalTo(OK));
+	}
+	
+	@Test
+	public void assignTicket_shouldReturn400WhenServicePointNameIsMissing() throws Exception {
+		HttpServletRequest request = mockRequestWithBody(
+		    "{\"ticketNumber\":\"T001\",\"status\":\"pending\"}");
+		ResponseEntity<?> response = (ResponseEntity<?>) controller.assignTicketToServicePoint(request);
+		assertThat(response.getStatusCode(), equalTo(BAD_REQUEST));
+	}
+	
+	@Test
+	public void assignTicket_shouldReturn400WhenStatusIsNull() throws Exception {
+		HttpServletRequest request = mockRequestWithBody(
+		    "{\"servicePointName\":\"Room1\",\"ticketNumber\":\"T001\",\"status\":null}");
+		ResponseEntity<?> response = (ResponseEntity<?>) controller.assignTicketToServicePoint(request);
+		assertThat(response.getStatusCode(), equalTo(BAD_REQUEST));
+	}
+	
+	@Test
+	public void assignTicket_shouldReturn400WhenServicePointNameIsNonStringType() throws Exception {
+		HttpServletRequest request = mockRequestWithBody(
+		    "{\"servicePointName\":123,\"ticketNumber\":\"T001\",\"status\":\"pending\"}");
+		ResponseEntity<?> response = (ResponseEntity<?>) controller.assignTicketToServicePoint(request);
+		assertThat(response.getStatusCode(), equalTo(BAD_REQUEST));
+	}
+	
+	@Test
+	public void assignTicket_shouldReturn400WhenStatusIsEmpty() throws Exception {
+		HttpServletRequest request = mockRequestWithBody(
+		    "{\"servicePointName\":\"Room1\",\"ticketNumber\":\"T001\",\"status\":\"\"}");
+		ResponseEntity<?> response = (ResponseEntity<?>) controller.assignTicketToServicePoint(request);
+		assertThat(response.getStatusCode(), equalTo(BAD_REQUEST));
+	}
+	
+	@Test
+	public void assignTicket_shouldReturn200WhenAllFieldsAreValid() throws Exception {
+		HttpServletRequest request = mockRequestWithBody(
+		    "{\"servicePointName\":\"Room1\",\"ticketNumber\":\"T001\",\"status\":\"pending\"}");
+		ResponseEntity<?> response = (ResponseEntity<?>) controller.assignTicketToServicePoint(request);
+		assertThat(response.getStatusCode(), equalTo(OK));
+	}
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. *(N/A - Critical backend logic fix)*
- [x] My work includes tests or is validated by existing tests.

## Summary

This PR fixes a critical `NullPointerException` (HTTP 500 API crash) and completes hardening of the `Legacy1xRestController`/`assignTicketToServicePoint` endpoint. Three issues were addressed based on Copilot AI review:

**1. NullPointerException on missing JSON keys** (original bug)
Jackson's `get(property)` returns `null` for missing fields — calling `.textValue()` or `.isEmpty()` on `null` crashed the endpoint.

**2. Silent type coercion (Copilot comment 1)**
The initial fix used `asText("")` which would coerce non-string types (e.g. `{"status": 123}`) into valid strings, violating the API contract. Now using explicit `isTextual()` + `isMissingNode()` + `isNull()` checks per Copilot's suggestion — non-string values are now rejected with `400`.

**3. Malformed JSON body crash (Copilot comment 2)**
`mapper.readTree("")` throws `JsonProcessingException` for blank or garbage input, which bubbled up as a `500`. Now caught and returned as `400 Bad Request`.

**4. Unit tests added (Copilot comment 3)**
Added `Legacy1xRestControllerAssignTicketTest` covering 8 scenarios: empty body, invalid JSON, missing fields, explicit `null` values, non-string types, empty strings, and the valid happy path.

## Related Issue
https://issues.openmrs.org/browse/O3-5607

## Other
No UI changes. Backend only.
