### PR TITLE
(fix) O3-5644: Use APIException with translatable message code for queue entry concurrency errors

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/impl/QueueEntryServiceImpl.java
@@ -126,7 +126,7 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 		queueEntryToStop.setEndedAt(queueEntryTransition.getTransitionDate());
 		boolean updated = dao.updateIfUnmodified(queueEntryToStop, expectedDateChanged);
 		if (!updated) {
-			throw new IllegalStateException("Queue entry was modified by another transaction");
+			throw new APIException("queue.entry.error.concurrentModification", new Object[0]);
 		}
 		
 		dao.flushSession();
@@ -139,8 +139,6 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 	 */
 	@Override
 	public QueueEntry undoTransition(@NotNull QueueEntry queueEntry) {
-		// TODO: Exceptions should be translatable and human readable on the frontend.
-		// See: https://openmrs.atlassian.net/browse/O3-2988
 		if (queueEntry.getId() == null) {
 			throw new IllegalArgumentException("Cannot undo transition on a queue entry that has not been saved");
 		}
@@ -167,7 +165,7 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 		prevQueueEntry.setEndedAt(null);
 		boolean updated = dao.updateIfUnmodified(prevQueueEntry, expectedDateChanged);
 		if (!updated) {
-			throw new IllegalStateException("Previous queue entry was modified by another transaction");
+			throw new APIException("queue.entry.error.concurrentModification", new Object[0]);
 		}
 		
 		getProxiedQueueEntryService().voidQueueEntry(queueEntry, "Transition undone");
@@ -290,8 +288,6 @@ public class QueueEntryServiceImpl extends BaseOpenmrsService implements QueueEn
 		if (prevQueueEntries.size() == 1) {
 			return prevQueueEntries.get(0);
 		} else if (prevQueueEntries.size() > 1) {
-			// TODO: Exceptions should be translatable and human readable on the frontend.
-			// See: https://openmrs.atlassian.net/browse/O3-2988
 			throw new IllegalStateException("Multiple previous queue entries found");
 		} else {
 			return null;

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -12,3 +12,4 @@ queue.entry.duplicate.patient=Patient already in the queue
 queue.entry.error.cannotStartBeforeVisitStartDate=Queue entry cannot start before the visit start date
 queue.entry.error.cannotStartAfterVisitStopDate=Queue entry cannot start after the visit stop date
 queue.entry.error.cannotEndAfterVisitStopDate=Queue entry cannot end after the visit stop date
+queue.entry.error.concurrentModification=Queue entry was modified by another transaction. Please refresh and try again.

--- a/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/api/QueueEntryServiceTest.java
@@ -40,6 +40,7 @@ import org.openmrs.Provider;
 import org.openmrs.User;
 import org.openmrs.Visit;
 import org.openmrs.VisitAttributeType;
+import org.openmrs.api.APIException;
 import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
@@ -402,7 +403,7 @@ public class QueueEntryServiceTest {
 		queueEntryService.undoTransition(endedEntry);
 	}
 	
-	@Test(expected = IllegalStateException.class)
+	@Test(expected = APIException.class)
 	public void shouldThrowWhenTransitioningConcurrentlyModifiedEntry() {
 		QueueEntry queueEntry = new QueueEntry();
 		queueEntry.setQueueEntryId(1);
@@ -420,7 +421,7 @@ public class QueueEntryServiceTest {
 		queueEntryService.transitionQueueEntry(transition);
 	}
 	
-	@Test(expected = IllegalStateException.class)
+	@Test(expected = APIException.class)
 	public void shouldThrowWhenUndoingTransitionOnConcurrentlyModifiedPreviousEntry() {
 		Queue queue1 = new Queue();
 		Patient patient1 = new Patient();


### PR DESCRIPTION
## Summary

The optimistic locking checks in `QueueEntryServiceImpl.transitionQueueEntry()` and `undoTransition()` currently throw a raw `IllegalStateException("Queue entry was modified by another transaction")`. This has two issues:

1. `IllegalStateException` is not an `APIException`, so the [RESTWS-1002](https://github.com/openmrs/openmrs-module-webservices.rest/pull/682) `translatedMessage` field does not apply - the frontend receives an untranslated English string.
2. It doesn't follow the existing pattern in this module where validation errors use message codes from `messages.properties` (e.g. `queue.entry.duplicate.patient`).

## Changes

- Replace `IllegalStateException` → `APIException("queue.entry.error.concurrentModification", null)` in both `transitionQueueEntry()` and `undoTransition()`
- Add `queue.entry.error.concurrentModification` to `messages.properties`
- Remove stale TODO referencing cancelled ticket O3-2988
- Update unit tests to expect `APIException`

## Related Issue

https://issues.openmrs.org/browse/O3-5644


[RESTWS-1002]: https://openmrs.atlassian.net/browse/RESTWS-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ