### PR TITLE
O3-5682: Ship Visit Queue Number visit attribute type

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/digitalSignage/QueueTicketAssignments.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/digitalSignage/QueueTicketAssignments.java
@@ -11,6 +11,7 @@ package org.openmrs.module.queue.api.digitalSignage;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -25,7 +26,7 @@ public class QueueTicketAssignments {
 	 * The object has: service point/room name as key for ease of search and update and object with
 	 * status and ticket number
 	 */
-	private static final Map<String, TicketAssignment> ACTIVE_QUEUE_TICKETS = new HashMap<>();
+	private static final Map<String, TicketAssignment> ACTIVE_QUEUE_TICKETS = new ConcurrentHashMap<>();
 	
 	/**
 	 * We want to control access to the ACTIVE_QUEUE_TICKETS so that requests are queued

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -766,7 +766,7 @@
             <column name="min_occurs" valueNumeric="0"/>
             <column name="max_occurs" valueNumeric="1"/>
             <column name="creator" valueNumeric="1"/>
-            <column name="date_created" valueDate="NOW()"/>
+            <column name="date_created" valueComputed="NOW()"/>
             <column name="retired" valueBoolean="false"/>
             <column name="uuid" value="c0c579b0-8e59-401d-8a4a-976a0b183519"/>
         </insert>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -749,4 +749,27 @@
         </sql>
     </changeSet>
 
+    <changeSet id="add_visit_queue_number_attribute_type_20260521" author="ujjawalprabhat">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM visit_attribute_type WHERE uuid = 'c0c579b0-8e59-401d-8a4a-976a0b183519';
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            Insert the "Visit Queue Number" visit attribute type used by the queue screen to display ticket numbers.
+            UUID matches the default value of `visitQueueNumberAttributeUuid` in @openmrs/esm-service-queues-app.
+        </comment>
+        <insert tableName="visit_attribute_type">
+            <column name="name" value="Visit Queue Number"/>
+            <column name="description" value="The visit queue number used to identify patients on the queue screen"/>
+            <column name="datatype" value="org.openmrs.customdatatype.datatype.FreeTextDatatype"/>
+            <column name="min_occurs" valueNumeric="0"/>
+            <column name="max_occurs" valueNumeric="1"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="NOW()"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="uuid" value="c0c579b0-8e59-401d-8a4a-976a0b183519"/>
+        </insert>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
Adds a Liquibase changeset that inserts the `visitQueueNumber` VisitAttributeType (UUID `c0c579b0-8e59-401d-8a4a-976a0b183519`) on module install/upgrade. Idempotent via `sqlCheck` precondition.

### Why?
The queue screen (`/spa/home/service-queues/screen`) is blank in default installs because the Call→serve flow depends on a "Visit Queue Number" visit attribute that nothing in the module ever creates. The frontend has long had a `visitQueueNumberAttributeUuid` config knob that was meant to be overridden by each distribution, but in practice the Reference Application and most installs ran on the `null` default — so `generateVisitQueueNumber` silently no-ops, visits never get a ticket number, and the assignticket POST silently 200s with nothing stored. Shipping the VAT in the module itself gives every install a working default; distributions that want their own UUID can still override via config.

## Related Issue 
[O3-5682](https://openmrs.atlassian.net/browse/O3-5682)

[O3-5682]: https://openmrs.atlassian.net/browse/O3-5682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ