### PR TITLE
O3-5696: Fix Wrong ORM mapping, duplicate DB lookup & null crash

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/api/dao/impl/AbstractBaseQueueDaoImpl.java
+++ b/api/src/main/java/org/openmrs/module/queue/api/dao/impl/AbstractBaseQueueDaoImpl.java
@@ -60,7 +60,6 @@ public class AbstractBaseQueueDaoImpl<Q extends OpenmrsObject & Auditable> imple
 	public Optional<Q> get(@NotNull String uuid) {
 		Criteria criteria = getCurrentSession().createCriteria(getClazz());
 		includeVoidedObjects(criteria, false);
-		criteria.add(eq("uuid", uuid)).uniqueResult();
 		return Optional.ofNullable((Q) criteria.add(eq("uuid", uuid)).uniqueResult());
 	}
 	

--- a/api/src/main/java/org/openmrs/module/queue/model/QueueEntry.java
+++ b/api/src/main/java/org/openmrs/module/queue/model/QueueEntry.java
@@ -16,7 +16,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 import java.util.Date;
@@ -89,7 +88,7 @@ public class QueueEntry extends BaseChangeableOpenmrsData {
 	
 	//The queue the patient is coming from, if any.
 	@ToString.Exclude
-	@OneToOne
+	@ManyToOne
 	@JoinColumn(name = "queue_coming_from", referencedColumnName = "queue_id")
 	private Queue queueComingFrom;
 	

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntryResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntryResource.java
@@ -25,6 +25,7 @@ import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.openmrs.Patient;
 import org.openmrs.PersonName;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.queue.api.QueueServicesWrapper;
@@ -281,8 +282,12 @@ public class QueueEntryResource extends DelegatingCrudResource<QueueEntry> {
 	
 	@PropertyGetter("display")
 	public String getDisplay(QueueEntry queueEntry) {
-		PersonName personName = queueEntry.getPatient().getPersonName();
-		return (personName == null ? queueEntry.getPatient().toString() : personName.getFullName());
+		Patient patient = queueEntry.getPatient();
+		if (patient == null) {
+			return queueEntry.getUuid();
+		}
+		PersonName personName = patient.getPersonName();
+		return (personName == null ? patient.toString() : personName.getFullName());
 	}
 	
 	@PropertyGetter("previousQueueEntry")

--- a/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntrySubResource.java
+++ b/omod/src/main/java/org/openmrs/module/queue/web/resources/QueueEntrySubResource.java
@@ -20,6 +20,8 @@ import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.*;
 import lombok.Setter;
+import org.openmrs.Patient;
+import org.openmrs.PersonName;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.queue.api.QueueServicesWrapper;
 import org.openmrs.module.queue.api.search.QueueEntrySearchCriteria;
@@ -232,10 +234,12 @@ public class QueueEntrySubResource extends DelegatingSubResource<QueueEntry, Que
 	@PropertyGetter("display")
 	public String getDisplay(QueueEntry queueEntry) {
 		//Display patient name
-		if (queueEntry.getPatient().getPerson().getPersonName() == null) {
-			return "";
+		Patient patient = queueEntry.getPatient();
+		if (patient == null) {
+			return queueEntry.getUuid();
 		}
-		return queueEntry.getPatient().getPerson().getPersonName().getFullName();
+		PersonName personName = patient.getPersonName();
+		return (personName == null ? patient.toString() : personName.getFullName());
 	}
 	
 	@Override

--- a/omod/src/test/java/org/openmrs/module/queue/web/resources/QueueEntryResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/queue/web/resources/QueueEntryResourceTest.java
@@ -429,6 +429,11 @@ public class QueueEntryResourceTest extends BaseQueueResourceTest<QueueEntry, Qu
 	}
 	
 	@Test
+	public void shouldReturnUuidForDisplayWhenPatientIsNull() {
+		assertThat(resource.getDisplay(queueEntry), is(QUEUE_ENTRY_UUID));
+	}
+	
+	@Test
 	public void shouldInstantiateNewDelegate() {
 		assertThat(getResource().newDelegate(), notNullValue());
 	}

--- a/omod/src/test/java/org/openmrs/module/queue/web/resources/QueueEntrySubResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/queue/web/resources/QueueEntrySubResourceTest.java
@@ -144,6 +144,11 @@ public class QueueEntrySubResourceTest extends BaseQueueResourceTest<QueueEntry,
 	}
 	
 	@Test
+	public void shouldReturnUuidForDisplayWhenPatientIsNull() {
+		assertThat(getResource().getDisplay(queueEntry), is(QUEUE_ENTRY_UUID));
+	}
+	
+	@Test
 	public void shouldInstantiateNewDelegate() {
 		assertThat(getResource().newDelegate(), notNullValue());
 	}


### PR DESCRIPTION
Three independent backend defects in the queue module:

- `QueueEntry.queueComingFrom` was mapped `@OneToOne` though many entries can transition from the same source queue. Switch to `@ManyToOne`, matching the other associations. Mapping correctness only, no behaviour change: Hibernate binds an owning-side `@OneToOne` with a join column as a `ManyToOneType` anyway, and the generated schema is identical.

- `AbstractBaseQueueDaoImpl.get(uuid)` executed its criteria query twice, discarding the first result. Drop the redundant call so each UUID lookup runs exactly one query (affects all queue DAOs via the base).

- `getDisplay` null-checked `personName` but dereferenced a possibly-null patient first, in both `QueueEntryResource` and `QueueEntrySubResource`. Null-check the patient and fall back to the queue entry UUID, in both, with unit tests. Hardening rather than a reproducible crash: `patient_id` is NOT NULL and validation rejects a null patient, so no in-module path writes such a row. It guards rows written from outside, and makes the two getters agree.