### PR TITLE
O3-5697: Add indexes to queue_entry for queue_id, patient_id & started_at/ended_at

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -749,4 +749,25 @@
         </sql>
     </changeSet>
 
+    <changeSet id="add_queue_entry_indexes_20260605" author="ujjawalprabhat">
+        <preConditions onFail="MARK_RAN" onError="WARN">
+            <not>
+                <indexExists tableName="queue_entry" indexName="queue_entry_started_ended_idx"/>
+            </not>
+        </preConditions>
+        <comment>
+            Add indexes to queue_entry (queue_id, patient_id, and composite started_at/ended_at)
+        </comment>
+        <createIndex tableName="queue_entry" indexName="queue_entry_queue_id_idx">
+            <column name="queue_id"/>
+        </createIndex>
+        <createIndex tableName="queue_entry" indexName="queue_entry_started_ended_idx">
+            <column name="started_at"/>
+            <column name="ended_at"/>
+        </createIndex>
+        <createIndex tableName="queue_entry" indexName="queue_entry_patient_id_idx">
+            <column name="patient_id"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
The `queue_entry` table of Service Queues  has no indexes on the columns those queries filter by (`queue_id`, `patient_id`, `started_at`, `ended_at`). Every query therefore scans the entire table.

On a fresh demo install with a handful of patients this is invisible. But in a real clinic with months or years of accumulated queue history (potentially tens of thousands of rows), the queue page gets progressively slower until staff notice it taking seconds to load and by then the table is large enough that adding indexes needs careful migration planning. Indexing it now, while it's small, avoids that.

## Related Issue
[O3-5697](https://openmrs.atlassian.net/browse/O3-5697)

[O3-5697]: https://openmrs.atlassian.net/browse/O3-5697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ