### PR TITLE
O3-5760: Return null rather than NaN for the average wait time

### DIFF
--- a/api/src/main/java/org/openmrs/module/queue/utils/QueueUtils.java
+++ b/api/src/main/java/org/openmrs/module/queue/utils/QueueUtils.java
@@ -55,10 +55,9 @@ public class QueueUtils {
 	/**
 	 * @param queueEntries the QueueEntries to check
 	 * @return the average duration for the entries, in minutes, between startedAt and endedAt, where
-	 *         both are non-null
+	 *         both are non-null, or null if no entry has both a startedAt and an endedAt
 	 */
-	public static double computeAverageWaitTimeInMinutes(List<QueueEntry> queueEntries) {
-		double averageWaitTime = 0.0;
+	public static Double computeAverageWaitTimeInMinutes(List<QueueEntry> queueEntries) {
 		if (queueEntries != null && !queueEntries.isEmpty()) {
 			double totalWaitTime = 0.0;
 			int numEntries = 0;
@@ -70,9 +69,12 @@ public class QueueUtils {
 					numEntries++;
 				}
 			}
-			averageWaitTime = totalWaitTime / numEntries;
+			// Returning 0.0 here would be indistinguishable from a genuine zero-minute wait
+			if (numEntries > 0) {
+				return totalWaitTime / numEntries;
+			}
 		}
-		return averageWaitTime;
+		return null;
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/module/queue/utils/QueueUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/utils/QueueUtilsTest.java
@@ -11,10 +11,14 @@ package org.openmrs.module.queue.utils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 
 import org.junit.Test;
+import org.openmrs.module.queue.model.QueueEntry;
 
 public class QueueUtilsTest {
 	
@@ -51,5 +55,32 @@ public class QueueUtilsTest {
 		assertThat(QueueUtils.datesOverlap(AUG_2, AUG_4, AUG_1, AUG_3), is(true)); // one starts within two
 		assertThat(QueueUtils.datesOverlap(AUG_3, AUG_4, AUG_1, AUG_2), is(false)); // one after two
 		assertThat(QueueUtils.datesOverlap(AUG_1, AUG_2, AUG_1, AUG_3), is(true)); // one starts when two starts
+	}
+	
+	@Test
+	public void shouldComputeAverageWaitTimeInMinutes() {
+		// Entries that waited 24 and 48 hours average out to 36 hours
+		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries(entry(AUG_1, AUG_2), entry(AUG_1, AUG_3))),
+		    is(2160.0));
+		
+		// Entries that have not ended yet are not part of the average
+		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries(entry(AUG_1, AUG_2), entry(AUG_1, NULL))), is(1440.0));
+		
+		// Test that there is no average to report rather than dividing by zero and returning NaN
+		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries(entry(AUG_1, NULL), entry(AUG_2, NULL))),
+		    is(nullValue()));
+		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries()), is(nullValue()));
+		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(null), is(nullValue()));
+	}
+	
+	private List<QueueEntry> entries(QueueEntry... queueEntries) {
+		return Arrays.asList(queueEntries);
+	}
+	
+	private QueueEntry entry(Date startedAt, Date endedAt) {
+		QueueEntry queueEntry = new QueueEntry();
+		queueEntry.setStartedAt(startedAt);
+		queueEntry.setEndedAt(endedAt);
+		return queueEntry;
 	}
 }

--- a/api/src/test/java/org/openmrs/module/queue/utils/QueueUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/queue/utils/QueueUtilsTest.java
@@ -63,11 +63,15 @@ public class QueueUtilsTest {
 		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries(entry(AUG_1, AUG_2), entry(AUG_1, AUG_3))),
 		    is(2160.0));
 		
-		// Entries that have not ended yet are not part of the average
+		// Entries missing a start or an end are not part of the average
 		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries(entry(AUG_1, AUG_2), entry(AUG_1, NULL))), is(1440.0));
+		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries(entry(NULL, AUG_2), entry(AUG_1, AUG_2))), is(1440.0));
+		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries(entry(NULL, NULL), entry(AUG_1, AUG_2))), is(1440.0));
 		
 		// Test that there is no average to report rather than dividing by zero and returning NaN
 		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries(entry(AUG_1, NULL), entry(AUG_2, NULL))),
+		    is(nullValue()));
+		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries(entry(NULL, NULL), entry(NULL, NULL))),
 		    is(nullValue()));
 		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(entries()), is(nullValue()));
 		assertThat(QueueUtils.computeAverageWaitTimeInMinutes(null), is(nullValue()));


### PR DESCRIPTION
## Summary
Came up while reviewing [openmrs-esm-patient-management#2615](https://github.com/openmrs/openmrs-esm-patient-management/pull/2615#discussion_r3606177037), where the Service Queues dashboard rendered "NaN mins".

`QueueUtils.computeAverageWaitTimeInMinutes` only guards against an empty entry list, but it averages over entries that have both a `startedAt` and an `endedAt`. A non-empty list where nothing has ended leaves the denominator at zero, so `queue-entry-metrics?metric=averageWaitTime` returns `{"averageWaitTime":"NaN"}`.

Returns `null` instead when there is no completed wait to average.

## Related Issue
[O3-5760](https://openmrs.atlassian.net/browse/O3-5760)

## Other
Related PR [here](https://github.com/openmrs/openmrs-esm-patient-management/pull/2615).

[O3-5760]: https://openmrs.atlassian.net/browse/O3-5760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ